### PR TITLE
Restrict to devnet and harden payment-required guard

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "CLI agent runner for elisym - provider mode, skills, crash recovery",
   "keywords": [
     "ai-agents",
@@ -44,7 +44,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.4.0",
+    "@elisym/sdk": "~0.4.1",
     "@solana/kit": "~6.8.0",
     "bs58": "~6.0.0",
     "chalk": "~5.6.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -164,17 +164,14 @@ export async function cmdInit(): Promise<void> {
     },
   ]);
 
-  // Step 4b: Solana network
+  // Step 4b: Solana network - only devnet is supported until the elisym-config
+  // program ships on mainnet.
   const { network } = await inquirer.prompt([
     {
       type: 'list',
       name: 'network',
       message: 'Solana network:',
-      choices: [
-        { name: 'devnet', value: 'devnet' },
-        { name: 'testnet', value: 'testnet' },
-        { name: 'mainnet', value: 'mainnet' },
-      ],
+      choices: [{ name: 'devnet', value: 'devnet' }],
       default: 'devnet',
     },
   ]);

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -138,7 +138,7 @@ export async function cmdProfile(name: string | undefined): Promise<void> {
           type: 'list',
           name: 'network',
           message: 'Network:',
-          choices: ['devnet', 'testnet', 'mainnet'],
+          choices: ['devnet'],
           default: currentNetwork,
         },
       ]);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -88,18 +88,7 @@ export async function cmdStart(name: string | undefined): Promise<void> {
       console.log(`     Balance  ${formatSol(balance)} (${balance} lamports)`);
 
       if (balance === 0) {
-        if (walletNetwork === 'mainnet') {
-          console.log(
-            '  ! Warning: wallet is empty. First incoming payment needs rent-exempt SOL (~0.00089 SOL).',
-          );
-        } else {
-          console.log('  ! Wallet is empty. Get devnet SOL: https://faucet.solana.com');
-        }
-      }
-      if (walletNetwork === 'mainnet' && !process.env.SOLANA_RPC_URL) {
-        console.log(
-          '  ! Warning: using public Solana RPC for mainnet. Set SOLANA_RPC_URL for reliable operation.',
-        );
+        console.log('  ! Wallet is empty. Get devnet SOL: https://faucet.solana.com');
       }
       console.log();
     } catch (e: any) {

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -17,19 +17,13 @@ export const WATCHDOG_SELF_PING_TIMEOUT_MS = 15_000;
 
 // --- Solana RPC ---
 
-export function getRpcUrl(network: string): string {
+export function getRpcUrl(_network: string): string {
   const envUrl = process.env.SOLANA_RPC_URL;
   if (envUrl) {
     return envUrl;
   }
-  switch (network) {
-    case 'mainnet':
-      return 'https://api.mainnet-beta.solana.com';
-    case 'testnet':
-      return 'https://api.testnet.solana.com';
-    default:
-      return 'https://api.devnet.solana.com';
-  }
+  // Only devnet is supported until the elisym-config program ships on mainnet.
+  return 'https://api.devnet.solana.com';
 }
 
 // --- SOL formatting (number only, no " SOL" suffix - use SDK's formatSol for display) ---

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -91,8 +91,15 @@ export class AgentRuntime {
 
   /** Fetch on-chain protocol config (fee, treasury). Always fetches fresh to avoid stale treasury. */
   private async fetchProtocolConfig(): Promise<ProtocolConfigInput> {
-    const cluster = this.config.network === 'mainnet' ? 'mainnet' : 'devnet';
-    const programId = getProtocolProgramId(cluster as 'devnet' | 'mainnet');
+    // Only devnet is supported until the elisym-config program ships on mainnet;
+    // agent configs pinned to other networks must be re-initialized explicitly.
+    if (this.config.network !== 'devnet') {
+      throw new Error(
+        `Network "${this.config.network}" is not supported. Only "devnet" is available ` +
+          `until the on-chain protocol program is deployed on mainnet.`,
+      );
+    }
+    const programId = getProtocolProgramId('devnet');
     const rpc = createSolanaRpc(getRpcUrl(this.config.network));
     const config = await getProtocolConfig(rpc, programId, { forceRefresh: true });
     return { feeBps: config.feeBps, treasury: config.treasury };

--- a/packages/cli/tests/helpers.test.ts
+++ b/packages/cli/tests/helpers.test.ts
@@ -8,20 +8,28 @@ import {
 } from '../src/helpers.js';
 
 describe('getRpcUrl', () => {
-  it('returns mainnet URL', () => {
-    expect(getRpcUrl('mainnet')).toBe('https://api.mainnet-beta.solana.com');
-  });
-
-  it('returns testnet URL', () => {
-    expect(getRpcUrl('testnet')).toBe('https://api.testnet.solana.com');
-  });
-
   it('returns devnet URL for devnet', () => {
     expect(getRpcUrl('devnet')).toBe('https://api.devnet.solana.com');
   });
 
-  it('returns devnet URL for unknown network', () => {
+  it('returns devnet URL regardless of input (only devnet is supported)', () => {
+    expect(getRpcUrl('mainnet')).toBe('https://api.devnet.solana.com');
+    expect(getRpcUrl('testnet')).toBe('https://api.devnet.solana.com');
     expect(getRpcUrl('unknown')).toBe('https://api.devnet.solana.com');
+  });
+
+  it('honours SOLANA_RPC_URL override', () => {
+    const prev = process.env.SOLANA_RPC_URL;
+    process.env.SOLANA_RPC_URL = 'https://custom.rpc';
+    try {
+      expect(getRpcUrl('devnet')).toBe('https://custom.rpc');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.SOLANA_RPC_URL;
+      } else {
+        process.env.SOLANA_RPC_URL = prev;
+      }
+    }
   });
 });
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -106,15 +106,15 @@ The bootstrap step is unchanged - the wizard collects the passphrase interactive
 
 ## Environment Variables
 
-| Variable                    | Description                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------- |
-| `ELISYM_AGENT`              | Load agent from `~/.elisym/agents/<name>/`                                    |
-| `ELISYM_NOSTR_SECRET`       | Nostr secret key (hex or nsec) for ephemeral mode                             |
-| `ELISYM_AGENT_NAME`         | Agent display name (default: mcp-agent)                                       |
-| `ELISYM_NETWORK`            | Solana network for ephemeral mode: `devnet` or `mainnet` (default: devnet)    |
-| `ELISYM_PASSPHRASE`         | Passphrase for encrypted agent configs (optional)                             |
-| `ELISYM_ALLOW_WITHDRAWAL`   | Set to `1` to override per-agent `security.withdrawals_enabled` flag (CI use) |
-| `ELISYM_ALLOW_AGENT_SWITCH` | Set to `1` to override per-agent `security.agent_switch_enabled` flag         |
+| Variable                    | Description                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| `ELISYM_AGENT`              | Load agent from `~/.elisym/agents/<name>/`                                      |
+| `ELISYM_NOSTR_SECRET`       | Nostr secret key (hex or nsec) for ephemeral mode                               |
+| `ELISYM_AGENT_NAME`         | Agent display name (default: mcp-agent)                                         |
+| `ELISYM_NETWORK`            | Solana network for ephemeral mode. Only `devnet` is supported (default: devnet) |
+| `ELISYM_PASSPHRASE`         | Passphrase for encrypted agent configs (optional)                               |
+| `ELISYM_ALLOW_WITHDRAWAL`   | Set to `1` to override per-agent `security.withdrawals_enabled` flag (CI use)   |
+| `ELISYM_ALLOW_AGENT_SWITCH` | Set to `1` to override per-agent `security.agent_switch_enabled` flag           |
 
 ## Usage Examples
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "MCP server for elisym - AI agent discovery, jobs, and payments",
   "keywords": [
     "ai-agents",
@@ -56,7 +56,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.4.0",
+    "@elisym/sdk": "~0.4.1",
     "@modelcontextprotocol/sdk": "~1.28.0",
     "@solana-program/system": "~0.12.0",
     "@solana/kit": "~6.8.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -39,7 +39,7 @@
         },
         {
           "name": "ELISYM_NETWORK",
-          "description": "Network for ephemeral mode: 'devnet' or 'mainnet' (default: devnet)",
+          "description": "Network for ephemeral mode. Only 'devnet' is supported (default: devnet)",
           "isRequired": false,
           "isSecret": false
         },

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -41,11 +41,23 @@ export interface AgentConfigData {
 }
 
 /**
- * Narrow a user-supplied string to a SolanaNetwork. Defaults to `devnet` for unknown
- * values so a freshly-migrated config does not silently broadcast to mainnet.
+ * Narrow a user-supplied string to a SolanaNetwork. Only `devnet` is supported
+ * at the moment; mainnet configs written by older versions throw a migration
+ * error so the user can reissue the agent explicitly instead of silently being
+ * downgraded.
  */
-function coerceNetwork(raw: string | undefined): SolanaNetwork {
-  return raw === 'mainnet' ? 'mainnet' : 'devnet';
+function coerceNetwork(raw: string | undefined, agentName: string): SolanaNetwork {
+  if (raw === undefined || raw === 'devnet') {
+    return 'devnet';
+  }
+  if (raw === 'mainnet') {
+    throw new Error(
+      `Agent "${agentName}" is configured for mainnet, which is not supported until the ` +
+        `elisym-config program is deployed there. Re-create the agent with --network devnet: ` +
+        `rm -rf ~/.elisym/agents/${agentName} && elisym-mcp init ${agentName} --network devnet`,
+    );
+  }
+  throw new Error(`Agent "${agentName}" has unsupported network "${raw}". Expected "devnet".`);
 }
 
 /**
@@ -83,7 +95,7 @@ export async function loadAgentConfig(name: string, passphrase?: string): Promis
     );
   }
 
-  const network = coerceNetwork(config.wallet?.network ?? config.payments?.[0]?.network);
+  const network = coerceNetwork(config.wallet?.network ?? config.payments?.[0]?.network, name);
 
   return {
     nostrSecretKey: config.identity.secret_key,

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -5,28 +5,29 @@ import { ElisymClient, ElisymIdentity, getProtocolConfig, getProtocolProgramId }
 import type { ProtocolConfigInput } from '@elisym/sdk';
 import { createSolanaRpc } from '@solana/kit';
 
-/** Supported Solana networks. `testnet` is intentionally excluded. */
-export type SolanaNetwork = 'devnet' | 'mainnet';
+/**
+ * Supported Solana networks. Currently devnet only - mainnet will be re-added
+ * once the elisym-config program is deployed and audited. `testnet` is not
+ * supported.
+ */
+export type SolanaNetwork = 'devnet';
 
 /** Map a network to its RPC endpoint. */
-export function rpcUrlFor(network: SolanaNetwork): string {
-  return network === 'mainnet'
-    ? 'https://api.mainnet-beta.solana.com'
-    : 'https://api.devnet.solana.com';
+export function rpcUrlFor(_network: SolanaNetwork): string {
+  return 'https://api.devnet.solana.com';
 }
 
 /** Fetch on-chain protocol config (fee, treasury) for a given network. */
-export async function fetchProtocolConfig(network: string): Promise<ProtocolConfigInput> {
-  const cluster = network === 'mainnet' ? 'mainnet' : 'devnet';
-  const programId = getProtocolProgramId(cluster);
-  const rpc = createSolanaRpc(rpcUrlFor(cluster));
+export async function fetchProtocolConfig(_network: SolanaNetwork): Promise<ProtocolConfigInput> {
+  const programId = getProtocolProgramId('devnet');
+  const rpc = createSolanaRpc(rpcUrlFor('devnet'));
   const config = await getProtocolConfig(rpc, programId, { forceRefresh: true });
   return { feeBps: config.feeBps, treasury: config.treasury };
 }
 
 /** Map a network to the explorer cluster query-string value. */
-export function explorerClusterFor(network: SolanaNetwork): string {
-  return network === 'mainnet' ? 'mainnet-beta' : 'devnet';
+export function explorerClusterFor(_network: SolanaNetwork): string {
+  return 'devnet';
 }
 
 /**

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -70,10 +70,16 @@ program.action(async () => {
     }
     const client = new ElisymClient({ relays: RELAYS });
     const name = process.env.ELISYM_AGENT_NAME ?? 'mcp-agent';
-    const network = process.env.ELISYM_NETWORK === 'mainnet' ? 'mainnet' : 'devnet';
+    if (process.env.ELISYM_NETWORK && process.env.ELISYM_NETWORK !== 'devnet') {
+      console.error(
+        `ELISYM_NETWORK="${process.env.ELISYM_NETWORK}" is not supported. ` +
+          `Only "devnet" is available until the on-chain protocol program ships on mainnet.`,
+      );
+      process.exit(1);
+    }
 
-    ctx.register({ client, identity, name, network, security: {} });
-    console.error(`Ephemeral agent: ${name} (${network})`);
+    ctx.register({ client, identity, name, network: 'devnet', security: {} });
+    console.error(`Ephemeral agent: ${name} (devnet)`);
   } else {
     // default agent selection is deterministic (alphabetical sort) so the
     // "first" agent doesn't depend on filesystem ordering.
@@ -109,7 +115,7 @@ program
   // capabilities are intentionally not exposed here: the MCP server runs in
   // customer-mode in 0.1.x, so an advertised capability list would be misleading.
   // provider-mode (0.2.0) will reintroduce this prompt.
-  .option('-n, --network <network>', 'Solana network (devnet|mainnet)', 'devnet')
+  .option('-n, --network <network>', 'Solana network (devnet only)', 'devnet')
   .option('--install', 'Also install into MCP clients')
   .action(async (name: string | undefined, options) => {
     const { default: inquirer } = await import('inquirer');
@@ -132,8 +138,8 @@ program
           type: 'list',
           name: 'network',
           message: 'Solana network:',
-          // testnet removed - only devnet and mainnet are supported.
-          choices: ['devnet', 'mainnet'],
+          // Only devnet is supported until the elisym-config program ships on mainnet.
+          choices: ['devnet'],
           default: 'devnet',
         },
       ]);
@@ -142,9 +148,11 @@ program
       options.network = answers.network;
     }
 
-    // enforce the two-network contract even when invoked non-interactively.
-    if (options.network !== 'devnet' && options.network !== 'mainnet') {
-      console.error(`Network must be "devnet" or "mainnet", got "${options.network}".`);
+    if (options.network !== 'devnet') {
+      console.error(
+        `Network must be "devnet", got "${options.network}". ` +
+          `Mainnet is not supported until the on-chain protocol program is deployed.`,
+      );
       process.exit(1);
     }
 
@@ -170,7 +178,7 @@ program
       nostrSecretKey: Buffer.from(nostrSecretKey).toString('hex'),
       solanaSecretKey: bs58.encode(solanaSecretBytes),
       solanaAddress: solanaSigner.address,
-      network: options.network as 'devnet' | 'mainnet',
+      network: 'devnet',
       security: { withdrawals_enabled: false, agent_switch_enabled: false },
       passphrase: passphrase || undefined,
     });

--- a/packages/mcp/src/tools/agent.ts
+++ b/packages/mcp/src/tools/agent.ts
@@ -39,7 +39,10 @@ const CreateAgentSchema = z.object({
   // customer-mode in 0.1.x and never publishes a NIP-89 capability card,
   // so an advertised capability list would be misleading. Provider-mode
   // (0.2.0) will reintroduce this field.
-  network: z.enum(['devnet', 'mainnet']).default('devnet'),
+  // Only devnet is supported until the elisym-config program ships on mainnet.
+  // Mainnet was previously advertised here but every paid flow then crashed at
+  // payment time - rejecting at schema level surfaces the error up front.
+  network: z.enum(['devnet']).default('devnet'),
   passphrase: z
     .string()
     .optional()

--- a/packages/mcp/src/tools/customer.ts
+++ b/packages/mcp/src/tools/customer.ts
@@ -267,12 +267,43 @@ export function makePaymentFeedbackHandler(opts: {
       );
       return;
     }
-    // Confirmation gate: if no max_price_lamports was set, reject with the price
-    // so the caller can confirm and retry with a limit.
-    if (opts.maxPriceLamports === undefined && amount !== undefined && amount > 0) {
+    // Source of truth for the amount we might sign is the JSON payload, not the
+    // feedback tag. Parse once and gate all subsequent checks on `signedAmount`
+    // so a malicious provider cannot advertise a low tag amount while embedding
+    // a large transfer in the signed request.
+    let parsedRequest: { amount?: unknown };
+    try {
+      parsedRequest = JSON.parse(paymentRequest) as { amount?: unknown };
+    } catch {
+      opts.rejectPayment(new Error('Provider sent a malformed payment_request (not valid JSON).'));
+      return;
+    }
+    const signedAmount =
+      typeof parsedRequest.amount === 'number' &&
+      Number.isInteger(parsedRequest.amount) &&
+      parsedRequest.amount > 0
+        ? parsedRequest.amount
+        : undefined;
+    if (
+      amount !== undefined &&
+      amount > 0 &&
+      signedAmount !== undefined &&
+      amount !== signedAmount
+    ) {
       opts.rejectPayment(
         new Error(
-          `Payment of ${formatSol(BigInt(amount))} required but no max_price_lamports set. ` +
+          `Payment request mismatch: feedback tag amount=${amount} differs from ` +
+            `signed amount=${signedAmount}. Refusing to proceed.`,
+        ),
+      );
+      return;
+    }
+    // Confirmation gate: if no max_price_lamports was set, reject with the price
+    // so the caller can confirm and retry with a limit.
+    if (opts.maxPriceLamports === undefined && signedAmount !== undefined) {
+      opts.rejectPayment(
+        new Error(
+          `Payment of ${formatSol(BigInt(signedAmount))} required but no max_price_lamports set. ` +
             `Retry with max_price_lamports to approve.`,
         ),
       );
@@ -280,12 +311,12 @@ export function makePaymentFeedbackHandler(opts: {
     }
     if (
       opts.maxPriceLamports !== undefined &&
-      amount !== undefined &&
-      amount > opts.maxPriceLamports
+      signedAmount !== undefined &&
+      signedAmount > opts.maxPriceLamports
     ) {
       opts.rejectPayment(
         new Error(
-          `Price ${formatSol(BigInt(amount))} exceeds max ${formatSol(BigInt(opts.maxPriceLamports))}`,
+          `Price ${formatSol(BigInt(signedAmount))} exceeds max ${formatSol(BigInt(opts.maxPriceLamports))}`,
         ),
       );
       return;
@@ -293,7 +324,7 @@ export function makePaymentFeedbackHandler(opts: {
     if (!opts.agent.solanaKeypair) {
       opts.resolveNoWallet(
         `Payment required but no Solana wallet configured.\n` +
-          `Amount: ${amount ? formatSol(BigInt(amount)) : 'unknown'}\n` +
+          `Amount: ${signedAmount !== undefined ? formatSol(BigInt(signedAmount)) : 'unknown'}\n` +
           `Payment request: ${paymentRequest}`,
       );
       return;

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -7,7 +7,7 @@ import { defineTool, textResult } from './types.js';
 const GetDashboardSchema = z.object({
   top_n: z.number().int().min(1).max(100).default(10),
   chain: z.enum(['solana']).default('solana'),
-  network: z.enum(['devnet', 'mainnet']).optional(),
+  network: z.enum(['devnet']).optional(),
   timeout_secs: z.number().int().min(1).max(60).default(15),
 });
 

--- a/packages/mcp/tests/payment-guard.test.ts
+++ b/packages/mcp/tests/payment-guard.test.ts
@@ -188,6 +188,43 @@ describe('makePaymentFeedbackHandler', () => {
     expect(rejectPayment.mock.calls[0]?.[0].message).toMatch(/no max_price_lamports set/);
   });
 
+  it('enforces max_price_lamports against the signed JSON amount, not the tag amount', () => {
+    // Wallet-drain regression: a malicious provider publishes a low tag amount
+    // (passes the cap) while the signed JSON carries a large transfer.
+    const executor = vi.fn(async () => 'sig-should-not-happen');
+    const { handler, rejectPayment } = buildHandler({
+      executor,
+      maxPriceLamports: 10_000,
+    });
+
+    handler('payment-required', 100, '{"recipient":"x","amount":1000000000}');
+    expect(executor).not.toHaveBeenCalled();
+    expect(rejectPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when feedback tag amount disagrees with the signed JSON amount', () => {
+    const executor = vi.fn(async () => 'sig-should-not-happen');
+    const { handler, rejectPayment } = buildHandler({
+      executor,
+      maxPriceLamports: 10_000_000_000,
+    });
+
+    handler('payment-required', 100, '{"recipient":"x","amount":1000000000}');
+    expect(executor).not.toHaveBeenCalled();
+    expect(rejectPayment).toHaveBeenCalledTimes(1);
+    expect(rejectPayment.mock.calls[0]?.[0].message).toMatch(/mismatch/);
+  });
+
+  it('rejects when payment_request is not valid JSON', () => {
+    const executor = vi.fn(async () => 'sig-should-not-happen');
+    const { handler, rejectPayment } = buildHandler({ executor, maxPriceLamports: 10_000 });
+
+    handler('payment-required', 1000, 'not-json');
+    expect(executor).not.toHaveBeenCalled();
+    expect(rejectPayment).toHaveBeenCalledTimes(1);
+    expect(rejectPayment.mock.calls[0]?.[0].message).toMatch(/malformed/);
+  });
+
   it('ignores feedback events whose status is not payment-required', () => {
     const executor = vi.fn(async () => 'sig');
     const { handler } = buildHandler({ executor, maxPriceLamports: 10000 });

--- a/packages/mcp/tests/tier2-critical.test.ts
+++ b/packages/mcp/tests/tier2-critical.test.ts
@@ -33,14 +33,12 @@ describe('tool registry', () => {
 });
 
 describe('network mapping', () => {
-  it('rpcUrlFor returns correct RPC per network', () => {
+  it('rpcUrlFor returns the devnet RPC', () => {
     expect(rpcUrlFor('devnet')).toBe('https://api.devnet.solana.com');
-    expect(rpcUrlFor('mainnet')).toBe('https://api.mainnet-beta.solana.com');
   });
 
   it('explorer cluster query param matches network', () => {
     expect(explorerClusterFor('devnet')).toBe('devnet');
-    expect(explorerClusterFor('mainnet')).toBe('mainnet-beta');
   });
 });
 
@@ -130,7 +128,7 @@ describe('config security flags', () => {
       relays: ['wss://relay.damus.io'],
       nostrSecretKey: '0'.repeat(64),
       solanaSecretKey: 'z'.repeat(87),
-      network: 'mainnet',
+      network: 'devnet',
       security: { agent_switch_enabled: true },
     });
     const merged = await updateAgentSecurity('merge-sec', { withdrawals_enabled: true });
@@ -138,7 +136,7 @@ describe('config security flags', () => {
     expect(merged.agent_switch_enabled).toBe(true);
 
     const reloaded = await loadAgentConfig('merge-sec');
-    expect(reloaded.network).toBe('mainnet');
+    expect(reloaded.network).toBe('devnet');
     expect(reloaded.security.withdrawals_enabled).toBe(true);
     expect(reloaded.security.agent_switch_enabled).toBe(true);
   });
@@ -151,17 +149,35 @@ describe('config security flags', () => {
       relays: ['wss://relay.damus.io'],
       nostrSecretKey: '0'.repeat(64),
       solanaSecretKey: 'z'.repeat(87),
-      network: 'mainnet',
+      network: 'devnet',
     });
     const loaded = await loadAgentConfig('net-agent');
-    expect(loaded.network).toBe('mainnet');
+    expect(loaded.network).toBe('devnet');
     // Also verify the raw config is parseable
     const raw = await readFile(
       join(process.env.HOME!, '.elisym', 'agents', 'net-agent', 'config.json'),
       'utf-8',
     );
     const parsed = parseConfig(raw);
-    expect(parsed.wallet?.network).toBe('mainnet');
+    expect(parsed.wallet?.network).toBe('devnet');
+  });
+
+  it('rejects loading a legacy mainnet config with a migration hint', async () => {
+    // Manually stage a pre-existing mainnet config on disk. saveAgentConfig now only
+    // accepts SolanaNetwork=devnet, so we write raw JSON to simulate the upgrade path.
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    const dir = join(tmpHome, '.elisym', 'agents', 'legacy-mainnet');
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'config.json'),
+      JSON.stringify({
+        identity: { secret_key: '0'.repeat(64), name: 'legacy-mainnet', description: 'old' },
+        relays: ['wss://relay.damus.io'],
+        capabilities: [],
+        wallet: { chain: 'solana', network: 'mainnet', secret_key: 'z'.repeat(87) },
+      }),
+    );
+    await expect(loadAgentConfig('legacy-mainnet')).rejects.toThrow(/mainnet/i);
   });
 });
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeScript SDK for elisym - AI agent discovery, marketplace, and payments on Nostr",
   "keywords": [
     "ai-agents",

--- a/packages/sdk/src/payment/solana.ts
+++ b/packages/sdk/src/payment/solana.ts
@@ -157,6 +157,14 @@ export class SolanaPaymentStrategy implements PaymentStrategy {
     const expectedFee = calculateProtocolFee(data.amount, config.feeBps);
     const treasury = config.treasury;
 
+    // feeBps=0 is a legal on-chain state (set_fee_bps only enforces <= MAX_FEE_BPS).
+    // createPaymentRequest still populates fee_address=treasury and fee_amount=0 in
+    // that case, which does not match either of the hasFee branches below. Mirror the
+    // `expectedFee > 0` guard in verifyPayment so both code paths agree.
+    if (expectedFee === 0) {
+      return null;
+    }
+
     const { fee_address, fee_amount } = data;
     const hasFeeAddress = typeof fee_address === 'string' && fee_address.length > 0;
     const hasFeeAmount = typeof fee_amount === 'number' && fee_amount > 0;

--- a/packages/sdk/tests/payment.test.ts
+++ b/packages/sdk/tests/payment.test.ts
@@ -8,10 +8,7 @@ import {
   getAddressDecoder,
 } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
-import { PROTOCOL_FEE_BPS, PROTOCOL_TREASURY } from '../src/constants';
-import { calculateProtocolFee } from '../src/payment/fee';
-import { buildPaymentInstructions, SolanaPaymentStrategy } from '../src/payment/solana';
-import type { ProtocolConfigInput } from '../src/payment/strategy';
+import { PROTOCOL_FEE_BPS, PROTOCOL_TREASURY, calculateProtocolFee, buildPaymentInstructions, SolanaPaymentStrategy, ProtocolConfigInput } from '../src';
 
 const RANDOM_ADDRESS_BYTES = 32;
 const ADDRESS_DECODER = getAddressDecoder();
@@ -144,6 +141,20 @@ describe('SolanaPaymentStrategy.validatePaymentRequest', () => {
 
   it('accepts without expected recipient', () => {
     const result = payment.validatePaymentRequest(JSON.stringify(validRequest), CONFIG);
+    expect(result).toBeNull();
+  });
+
+  it('accepts fee_amount=0 when feeBps=0 (legal on-chain state)', () => {
+    // Regression: set_fee_bps enforces <= MAX_FEE_BPS but not > 0. When an admin
+    // sets feeBps=0, createPaymentRequest emits fee_address=treasury, fee_amount=0.
+    // validatePaymentRequest must accept the same request it just produced.
+    const zeroFeeConfig = { feeBps: 0, treasury: PROTOCOL_TREASURY };
+    const zeroFeeRequest = { ...validRequest, fee_amount: 0 };
+    const result = payment.validatePaymentRequest(
+      JSON.stringify(zeroFeeRequest),
+      zeroFeeConfig,
+      recipientAddr,
+    );
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
- CLI/MCP: drop mainnet/testnet from prompts, RPC mapping, and schemas until the elisym-config program ships on mainnet. Legacy mainnet configs throw a migration hint instead of silently downgrading.
- MCP customer flow: parse payment_request JSON and gate max_price_lamports against the signed amount, not the feedback tag. Reject tag/JSON amount mismatches and malformed JSON up front.
- SDK validatePaymentRequest: short-circuit when expectedFee === 0 so it agrees with verifyPayment for the legal feeBps=0 state.