### PR TITLE
Fix MCP price display to honour the provider's asset (USDC vs SOL)

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/mcp",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "MCP server for elisym - AI agent discovery, jobs, and payments",
   "keywords": [
     "ai-agents",

--- a/packages/mcp/src/tools/customer.ts
+++ b/packages/mcp/src/tools/customer.ts
@@ -1,5 +1,5 @@
-import { toDTag, DEFAULT_KIND_OFFSET, SolanaPaymentStrategy } from '@elisym/sdk';
-import type { Agent as ProviderAgent, PaymentRequestData } from '@elisym/sdk';
+import { formatAssetAmount, toDTag, DEFAULT_KIND_OFFSET, SolanaPaymentStrategy } from '@elisym/sdk';
+import type { Agent as ProviderAgent, Asset, PaymentRequestData } from '@elisym/sdk';
 import {
   createKeyPairSignerFromBytes,
   createSolanaRpc,
@@ -28,9 +28,8 @@ import {
   isLikelyBase64,
 } from '../sanitize.js';
 import {
+  assetFromCardPayment,
   checkLen,
-  formatSol,
-  formatSolShort,
   payment,
   MAX_INPUT_LEN,
   MAX_NPUB_LEN,
@@ -321,12 +320,24 @@ export function makePaymentFeedbackHandler(opts: {
       );
       return;
     }
+    // Resolve asset from the signed request before any user-facing string so
+    // confirmation/cap messages render in the provider's actual asset (SOL, USDC, ...)
+    // rather than always reading "SOL". An unknown asset is a hard failure - we cannot
+    // safely display, charge against, or compare to the session cap if we don't know
+    // the unit.
+    let asset: Asset;
+    try {
+      asset = resolveAssetFromPaymentRequest(parsedRequest as PaymentRequestData);
+    } catch (e) {
+      opts.rejectPayment(e instanceof Error ? e : new Error(String(e)));
+      return;
+    }
     // Confirmation gate: if no max_price_lamports was set, reject with the price
     // so the caller can confirm and retry with a limit.
     if (opts.maxPriceLamports === undefined && signedAmount !== undefined) {
       opts.rejectPayment(
         new Error(
-          `Payment of ${formatSol(BigInt(signedAmount))} required but no max_price_lamports set. ` +
+          `Payment of ${formatAssetAmount(asset, BigInt(signedAmount))} required but no max_price_lamports set. ` +
             `Retry with max_price_lamports to approve.`,
         ),
       );
@@ -339,7 +350,7 @@ export function makePaymentFeedbackHandler(opts: {
     ) {
       opts.rejectPayment(
         new Error(
-          `Price ${formatSol(BigInt(signedAmount))} exceeds max ${formatSol(BigInt(opts.maxPriceLamports))}`,
+          `Price ${formatAssetAmount(asset, BigInt(signedAmount))} exceeds max ${formatAssetAmount(asset, BigInt(opts.maxPriceLamports))}`,
         ),
       );
       return;
@@ -347,7 +358,7 @@ export function makePaymentFeedbackHandler(opts: {
     if (!opts.agent.solanaKeypair) {
       opts.resolveNoWallet(
         `Payment required but no Solana wallet configured.\n` +
-          `Amount: ${signedAmount !== undefined ? formatSol(BigInt(signedAmount)) : 'unknown'}\n` +
+          `Amount: ${signedAmount !== undefined ? formatAssetAmount(asset, BigInt(signedAmount)) : 'unknown'}\n` +
           `Payment request: ${paymentRequest}`,
       );
       return;
@@ -357,7 +368,6 @@ export function makePaymentFeedbackHandler(opts: {
     // total wallet outflow. Reserving (check + increment in one step) closes the
     // race where two concurrent handlers both pass a read-only check against a
     // stale counter.
-    const asset = resolveAssetFromPaymentRequest(parsedRequest as PaymentRequestData);
     let reservedAmount: bigint | undefined;
     if (signedAmount !== undefined) {
       try {
@@ -846,9 +856,10 @@ export const customerTools: ToolDefinition[] = [
       }
 
       const price = card.payment?.job_price ?? 0;
+      const cardAsset = assetFromCardPayment(card.payment);
       if (input.max_price_lamports !== undefined && price > input.max_price_lamports) {
         return errorResult(
-          `Price ${formatSolShort(BigInt(price))} exceeds max ${formatSolShort(BigInt(input.max_price_lamports))}`,
+          `Price ${formatAssetAmount(cardAsset, BigInt(price))} exceeds max ${formatAssetAmount(cardAsset, BigInt(input.max_price_lamports))}`,
         );
       }
 
@@ -861,7 +872,7 @@ export const customerTools: ToolDefinition[] = [
               type: 'text' as const,
               text:
                 `Capability "${input.capability}" from "${provider.name || input.provider_npub}" ` +
-                `costs ${formatSolShort(BigInt(price))}.\n\n` +
+                `costs ${formatAssetAmount(cardAsset, BigInt(price))}.\n\n` +
                 `To confirm, call buy_capability again with max_price_lamports set ` +
                 `(e.g. ${price} or higher).`,
             },

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -1,6 +1,7 @@
+import { formatAssetAmount } from '@elisym/sdk';
 import { z } from 'zod';
 import { sanitizeField, sanitizeUntrusted } from '../sanitize.js';
-import { formatSolShort } from '../utils.js';
+import { assetFromCardPayment } from '../utils.js';
 import type { ToolDefinition } from './types.js';
 import { defineTool, textResult } from './types.js';
 
@@ -34,13 +35,13 @@ export const dashboardTools: ToolDefinition[] = [
       const rows = filtered
         .map((a) => {
           const mainCard = a.cards[0];
+          const mainAsset = assetFromCardPayment(mainCard?.payment);
+          const mainPrice = mainCard?.payment?.job_price;
           return {
             name: sanitizeField(a.name || mainCard?.name || 'unknown', 30),
             npub: a.npub,
             capabilities: (mainCard?.capabilities ?? []).join(', '),
-            price: mainCard?.payment?.job_price
-              ? formatSolShort(BigInt(mainCard.payment.job_price))
-              : 'free',
+            price: mainPrice ? formatAssetAmount(mainAsset, BigInt(mainPrice)) : 'free',
             cards_count: a.cards.length,
           };
         })

--- a/packages/mcp/src/tools/discovery.ts
+++ b/packages/mcp/src/tools/discovery.ts
@@ -1,6 +1,7 @@
+import { formatAssetAmount } from '@elisym/sdk';
 import { z } from 'zod';
 import { sanitizeField, sanitizeUntrusted } from '../sanitize.js';
-import { MAX_CAPABILITIES, formatSolShort } from '../utils.js';
+import { MAX_CAPABILITIES, assetFromCardPayment } from '../utils.js';
 import type { ToolDefinition } from './types.js';
 import { defineTool, textResult, errorResult } from './types.js';
 
@@ -262,17 +263,22 @@ export const discoveryTools: ToolDefinition[] = [
       const results = filtered.map((a) => ({
         npub: a.npub,
         name: sanitizeField(a.name || '', 200),
-        cards: a.cards.map((c) => ({
-          name: sanitizeField(c.name || '', 200),
-          description: sanitizeField(c.description || '', 500),
-          capabilities: c.capabilities,
-          job_price_lamports: c.payment?.job_price,
-          price_display: c.payment?.job_price
-            ? formatSolShort(BigInt(c.payment.job_price))
-            : 'free',
-          chain: c.payment?.chain,
-          network: c.payment?.network,
-        })),
+        cards: a.cards.map((card) => {
+          const asset = assetFromCardPayment(card.payment);
+          const price = card.payment?.job_price;
+          return {
+            name: sanitizeField(card.name || '', 200),
+            description: sanitizeField(card.description || '', 500),
+            capabilities: card.capabilities,
+            job_price_subunits: price,
+            price_display: price ? formatAssetAmount(asset, BigInt(price)) : 'free',
+            asset_token: asset.token,
+            asset_symbol: asset.symbol,
+            asset_mint: asset.mint,
+            chain: card.payment?.chain,
+            network: card.payment?.network,
+          };
+        }),
         supported_kinds: a.supportedKinds,
       }));
 

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -4,7 +4,8 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { SolanaPaymentStrategy, LIMITS } from '@elisym/sdk';
+import { NATIVE_SOL, resolveKnownAsset, SolanaPaymentStrategy, LIMITS } from '@elisym/sdk';
+import type { Asset, Chain, PaymentInfo } from '@elisym/sdk';
 
 /** Standard LAMPORTS_PER_SOL as a BigInt for integer math. */
 const LAMPORTS_PER_SOL = 1_000_000_000n;
@@ -50,6 +51,37 @@ export function formatSolShort(lamports: bigint): string {
   const whole = lamports / LAMPORTS_PER_SOL;
   const frac = (lamports % LAMPORTS_PER_SOL) / 100_000n;
   return `${whole}.${frac.toString().padStart(4, '0')} SOL`;
+}
+
+/**
+ * Resolve the `Asset` a capability card is denominated in for display purposes.
+ *
+ * Card schema (`PaymentInfo`) carries `chain`/`token`/`mint`/`decimals`/`symbol`.
+ * This helper:
+ *   1. tries to map to a `KNOWN_ASSETS` entry from the SDK (the verifier-truth source);
+ *   2. falls back to a self-describing card (token + symbol + decimals) for forward-compat
+ *      with assets the SDK doesn't yet recognize - safe because we use this only for the
+ *      MCP display layer, never for on-chain verify;
+ *   3. defaults to `NATIVE_SOL` when the card omits payment metadata or only carries chain.
+ */
+export function assetFromCardPayment(payment: PaymentInfo | undefined): Asset {
+  if (!payment) {
+    return NATIVE_SOL;
+  }
+  const known = resolveKnownAsset(payment.chain, payment.token ?? 'sol', payment.mint);
+  if (known) {
+    return known;
+  }
+  if (payment.token && payment.symbol && typeof payment.decimals === 'number') {
+    return {
+      chain: payment.chain as Chain,
+      token: payment.token,
+      mint: payment.mint,
+      symbol: payment.symbol,
+      decimals: payment.decimals,
+    };
+  }
+  return NATIVE_SOL;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `find_agents`, `get_dashboard`, `buy_capability` and the in-flight `payment-required` confirmation/cap/no-wallet gates were calling `formatSolShort` / `formatSol` regardless of the card's actual asset, so a USDC-priced provider rendered as "0.00001 SOL" to the LLM.
- Resolve the asset from the card's `PaymentInfo` (or, for the in-flight gates, from the already-parsed signed `PaymentRequestData`) and format prices via `formatAssetAmount`.
- `find_agents` now also exposes `asset_token` / `asset_symbol` / `asset_mint`. The response field `job_price_lamports` is renamed to `job_price_subunits` because the unit is no longer SOL-specific.
- New helper `assetFromCardPayment(payment)` in `packages/mcp/src/utils.ts`: maps to a `KNOWN_ASSETS` entry first, falls back to a self-describing card (token + symbol + decimals) for forward-compat, defaults to `NATIVE_SOL`.
- `makePaymentFeedbackHandler` resolves the asset right after parsing the request JSON; an unknown asset now goes through `rejectPayment` instead of throwing out of the handler.

What is intentionally NOT in this PR:
- The `max_price_lamports` parameter keeps its name. Renaming is a public-API change to MCP tools and belongs in a separate PR.
- Verifier and session-spend tracking are unchanged - they were already multi-asset-correct.

## Test plan

- [x] `bun qa` green (build + 240 MCP tests + types + lint + format + spell)
- [ ] Manual smoke: `find_agents` against a USDC provider returns `price_display: "0.010000 USDC"` and `asset_symbol: "USDC"`
- [ ] Manual smoke: `buy_capability` confirmation gate quotes USDC for a USDC-priced card
- [ ] Manual smoke: `submit_and_pay_job` with `max_price_lamports` undefined rejects with "Payment of X.XX USDC required" for a USDC provider