### PR TITLE
perf: Add @elisym/perf local capacity-test stack with Q1-Q4 baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ test-ledger/
 # Keypairs (NEVER commit)
 *-keypair.json
 !programs/**/id-*.json.example
+
+# Local agent state - contains nostr_secret_key (NEVER commit)
+.elisym/
+
+# @elisym/perf generated artifacts
+packages/perf/k6/fixtures/events-*.json
+packages/perf/k6/reports/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 dist/
 build/
 bun.lock
+packages/perf/k6/fixtures/
+packages/perf/k6/reports/
+.elisym/

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "elisym": "./dist/index.js",
       },
       "dependencies": {
-        "@elisym/sdk": "~0.15.0",
+        "@elisym/sdk": "~0.20.0",
         "@solana-program/memo": "~0.11.0",
         "@solana-program/system": "~0.12.0",
         "@solana-program/token": "~0.5.0",
@@ -74,6 +74,7 @@
         "p-limit": "~6.2.0",
         "pino": "~9.5.0",
         "pino-pretty": "~11.3.0",
+        "prom-client": "~15.1.0",
         "yaml": "~2.8.3",
       },
       "devDependencies": {
@@ -122,6 +123,23 @@
         "tsup": "~8.4.0",
         "typescript": "~5.7.0",
         "vitest": "~3.0.0",
+      },
+    },
+    "packages/perf": {
+      "name": "@elisym/perf",
+      "version": "0.0.0",
+      "dependencies": {
+        "@elisym/sdk": "workspace:*",
+        "@modelcontextprotocol/sdk": "~1.21.0",
+        "@solana/kit": "~6.8.0",
+        "hono": "~4.7.0",
+        "nostr-tools": "~2.23.0",
+        "prom-client": "~15.1.0",
+      },
+      "devDependencies": {
+        "@types/bun": "~1.3.0",
+        "@types/node": "~22.0.0",
+        "typescript": "~5.7.0",
       },
     },
     "packages/sdk": {
@@ -363,6 +381,8 @@
 
     "@elisym/mcp": ["@elisym/mcp@workspace:packages/mcp"],
 
+    "@elisym/perf": ["@elisym/perf@workspace:packages/perf"],
+
     "@elisym/sdk": ["@elisym/sdk@workspace:packages/sdk"],
 
     "@emurgo/cardano-serialization-lib-browser": ["@emurgo/cardano-serialization-lib-browser@13.2.1", "", {}, "sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag=="],
@@ -522,6 +542,8 @@
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.42.0", "", { "os": "android", "cpu": "arm" }, "sha512-dsqPTYsozeokRjlrt/b4E7Pj0z3eS3Eg74TWQuuKbjY4VttBmA88rB7d50Xrd+TZ986qdXCNeZRPEzZHAe+jow=="],
 
@@ -1021,6 +1043,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
@@ -1213,6 +1237,8 @@
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
+    "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
+
     "bip66": ["bip66@2.0.0", "", {}, "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ=="],
 
     "bitcoin-ops": ["bitcoin-ops@1.4.1", "", {}, "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="],
@@ -1266,6 +1292,8 @@
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
     "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -1681,7 +1709,7 @@
 
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
 
-    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+    "hono": ["hono@4.7.11", "", {}, "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
@@ -2207,6 +2235,8 @@
 
     "process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
+    "prom-client": ["prom-client@15.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.4.0", "tdigest": "^0.1.1" } }, "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g=="],
+
     "promise": ["promise@8.3.0", "", { "dependencies": { "asap": "~2.0.6" } }, "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -2466,6 +2496,8 @@
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
 
     "terser": ["terser@5.46.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ=="],
 
@@ -2733,6 +2765,8 @@
 
     "@codama/visitors-core/@codama/nodes": ["@codama/nodes@1.3.4", "", { "dependencies": { "@codama/errors": "1.3.4", "@codama/node-types": "1.3.4" } }, "sha512-Q3eS/kMqiozZzlpY/otVfQQ9M3pRdCS0D1dlB3TyuHWBAJiAGPfjRT21KQ4M8xub6eTWJY7PwT7sykPqS/fQPg=="],
 
+    "@elisym/perf/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.21.2", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-HXR5NeVbaL45KuPRqfBQL/hcdc8Y197ALj5G75M5qUMcOk2at0bj2Nns4ZnjU2mTw52360TK63oDqvRjc1iPRQ=="],
+
     "@elisym/sdk/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@ethereumjs/common/@ethereumjs/util": ["@ethereumjs/util@10.1.1", "", { "dependencies": { "@ethereumjs/rlp": "^10.1.1", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1" } }, "sha512-r2EhaeEmLZXVs1dT2HJFQysAkr63ZWATu/9tgYSp1IlvjvwyC++DLg5kCDwMM49HBq3sOAhrPnXkoqf9DV2gbw=="],
@@ -2758,6 +2792,8 @@
     "@keystonehq/sol-keyring/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "@ledgerhq/devices/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@modelcontextprotocol/sdk/hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "@project-serum/sol-wallet-adapter/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
@@ -2964,6 +3000,8 @@
     "blake-hash/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "bun-types/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "chrome-launcher/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
@@ -3200,6 +3238,8 @@
     "@codama/visitors-core/@codama/errors/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "@codama/visitors-core/@codama/nodes/@codama/node-types": ["@codama/node-types@1.3.4", "", {}, "sha512-WOKU9v019gfX58y+I+hadokckvYLEZKvcsXpf578S+B+sV9YBCOhIjlzDDONcfe9iGUw49M6VpyWkp+EenasLg=="],
+
+    "@elisym/perf/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "@elisym/sdk/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3506,6 +3546,8 @@
     "browserify-sign/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "chrome-launcher/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -108,3 +108,8 @@ wouter
 zeroize
 zeroized
 zod
+fanout
+healthz
+strfry
+misconfig
+tunables

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "program:test": "cargo test --package elisym-config --test config -- --test-threads=1",
     "program:test:ts": "vitest run --config programs/elisym-config/vitest.config.ts",
     "program:deploy:devnet": "anchor deploy --provider.cluster devnet",
-    "program:idl:generate": "anchor build && cp target/idl/elisym_config.json packages/config-client/idl.json"
+    "program:idl:generate": "anchor build && cp target/idl/elisym_config.json packages/config-client/idl.json",
+    "perf:up": "bash packages/perf/scripts/stack-up.sh",
+    "perf:down": "bash packages/perf/scripts/stack-down.sh",
+    "perf:run": "bash packages/perf/scripts/run.sh",
+    "perf:bridge": "bun --hot --cwd packages/perf bridge/src/server.ts",
+    "perf:validator": "bash packages/perf/scripts/start-validator.sh"
   },
   "devDependencies": {
     "cspell": "~9.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,7 @@
     "p-limit": "~6.2.0",
     "pino": "~9.5.0",
     "pino-pretty": "~11.3.0",
+    "prom-client": "~15.1.0",
     "yaml": "~2.8.3"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -56,9 +56,18 @@ import {
 } from '../llm';
 import { cacheKeyFor, resolveTripleForOverride } from '../llm/cache.js';
 import { resolveProviderApiKey } from '../llm/keys.js';
+import { isMockLlmEnabled, refuseMockLlmInProduction } from '../llm/mock.js';
 import { resolveSkillLlm, type ResolvedSkillLlm } from '../llm/resolve.js';
 import { createLogger } from '../logging.js';
-import { AgentRuntime, type RuntimeConfig } from '../runtime.js';
+import {
+  createMetricsContext,
+  instrumentCallbacks,
+  parseMetricsPort,
+  serveMetrics,
+  startGaugePolling,
+  type MetricsServer,
+} from '../metrics.js';
+import { AgentRuntime, type RuntimeCallbacks, type RuntimeConfig } from '../runtime.js';
 import { SkillRegistry, type SkillContext, type SkillLlmOverride } from '../skill';
 import type { LlmClient } from '../skill/index.js';
 import { loadSkillsFromDir } from '../skill/loader.js';
@@ -67,12 +76,21 @@ import { startWatchdog } from '../watchdog.js';
 
 export interface StartOptions {
   verbose?: boolean;
+  metricsPort?: string;
 }
 
 export async function cmdStart(
   nameArg: string | undefined,
   options: StartOptions = {},
 ): Promise<void> {
+  // Refuse MOCK_LLM in production before any state mutates.
+  refuseMockLlmInProduction();
+  if (isMockLlmEnabled()) {
+    console.log(
+      '  ! MOCK_LLM=1 active - skill LLM calls return synthetic replies. NOT for production use.',
+    );
+  }
+
   const cwd = process.cwd();
 
   // -- Step 1: Resolve agent name --
@@ -690,35 +708,55 @@ export async function cmdStart(
     diagLog('LLM health monitor armed (lazy recovery, 5min interval).');
   }
 
+  // -- Step 14b: Optional Prometheus metrics exporter --
+  // Off by default; --metrics-port enables a tiny http server on loopback.
+  // Used by packages/perf for local capacity testing.
+  const metricsPort = parseMetricsPort(options.metricsPort);
+  const metricsCtx = metricsPort === undefined ? undefined : createMetricsContext();
+  let metricsServer: MetricsServer | undefined;
+  let stopMetricsPolling: (() => void) | undefined;
+
+  const userCallbacks: RuntimeCallbacks = {
+    onJobReceived: (job) => {
+      const cap = job.tags.find((t) => t !== 'elisym') ?? 'unknown';
+      // Never log job.input here - capability tag is the only descriptor needed.
+      process.stdout.write(`  [job] ${job.jobId.slice(0, 16)} | cap=${cap}\n`);
+      logger.info({ event: 'job_received', jobId: job.jobId, capability: cap });
+    },
+    onJobCompleted: (jobId) => {
+      process.stdout.write(`  [job] ${jobId.slice(0, 16)} | delivered\n`);
+      logger.info({ event: 'job_delivered', jobId });
+    },
+    onJobError: (jobId, error) => {
+      process.stderr.write(`  [job] ${jobId.slice(0, 16)} | error: ${error}\n`);
+      logger.error({ event: 'job_error', jobId, error });
+    },
+    onLog: diagLog,
+    onStop: () => {
+      watchdog.stop();
+      llmHeartbeat?.stop();
+      stopMetricsPolling?.();
+      if (metricsServer) {
+        void metricsServer.close();
+      }
+    },
+  };
+
   const runtime = new AgentRuntime(
     transport,
     registry,
     skillCtx,
     runtimeConfig,
     ledger,
-    {
-      onJobReceived: (job) => {
-        const cap = job.tags.find((t) => t !== 'elisym') ?? 'unknown';
-        // Never log job.input here - capability tag is the only descriptor needed.
-        process.stdout.write(`  [job] ${job.jobId.slice(0, 16)} | cap=${cap}\n`);
-        logger.info({ event: 'job_received', jobId: job.jobId, capability: cap });
-      },
-      onJobCompleted: (jobId) => {
-        process.stdout.write(`  [job] ${jobId.slice(0, 16)} | delivered\n`);
-        logger.info({ event: 'job_delivered', jobId });
-      },
-      onJobError: (jobId, error) => {
-        process.stderr.write(`  [job] ${jobId.slice(0, 16)} | error: ${error}\n`);
-        logger.error({ event: 'job_error', jobId, error });
-      },
-      onLog: diagLog,
-      onStop: () => {
-        watchdog.stop();
-        llmHeartbeat?.stop();
-      },
-    },
+    metricsCtx ? instrumentCallbacks(metricsCtx, userCallbacks) : userCallbacks,
     healthMonitor,
   );
+
+  if (metricsCtx && metricsPort !== undefined) {
+    stopMetricsPolling = startGaugePolling(metricsCtx, runtime, healthMonitor);
+    metricsServer = await serveMetrics(metricsCtx, metricsPort);
+    console.log(`  * Metrics: ${metricsServer.url}`);
+  }
 
   // -- Step 15: Run --
   console.log('  * Running. Press Ctrl+C to stop.\n');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,8 +77,12 @@ program
     '-v, --verbose',
     'Enable debug logging (relay lifecycle, publish acks, subscription EOSE). Also togglable via ELISYM_DEBUG=1 or LOG_LEVEL=debug.',
   )
+  .option(
+    '--metrics-port <port>',
+    'Expose Prometheus metrics on http://127.0.0.1:<port>/metrics. Off by default. Override bind host with ELISYM_METRICS_HOST.',
+  )
   .action(
-    safe(async (name: string | undefined, options: { verbose?: boolean }) => {
+    safe(async (name: string | undefined, options: { verbose?: boolean; metricsPort?: string }) => {
       await cmdStart(name, options);
     }),
   );

--- a/packages/cli/src/llm/index.ts
+++ b/packages/cli/src/llm/index.ts
@@ -17,6 +17,7 @@
  */
 
 import type { LlmClient } from '@elisym/sdk/skills';
+import { createMockLlmClient, isMockLlmEnabled } from './mock';
 import { getLlmProvider, getRegisteredProviderIds, type LlmKeyVerification } from './registry';
 
 export type { LlmKeyVerification, LlmProviderDescriptor, LlmUsage } from './registry';
@@ -44,6 +45,12 @@ export interface LlmConfig {
  * `provider:` override).
  */
 export function createLlmClient(config: LlmConfig): LlmClient {
+  // MOCK_LLM short-circuit for local capacity tests. Honours the same
+  // provider lookup so unknown providers still error consistently, but
+  // returns synthetic replies instead of hitting the network.
+  if (isMockLlmEnabled()) {
+    return createMockLlmClient();
+  }
   const descriptor = getLlmProvider(config.provider);
   if (!descriptor) {
     const known = getRegisteredProviderIds().join(', ') || '<none>';

--- a/packages/cli/src/llm/mock.ts
+++ b/packages/cli/src/llm/mock.ts
@@ -1,0 +1,130 @@
+/**
+ * Mock LLM client for local capacity tests (Phase 7 of perf plan).
+ *
+ * Activated by `MOCK_LLM=1`. Refuses to start when `NODE_ENV=production`
+ * so a misconfigured deployment cannot accidentally serve mock answers.
+ *
+ * Tunables (env):
+ *   MOCK_LLM_LATENCY_MS=0           constant base latency before reply
+ *   MOCK_LLM_JITTER_MS=200          uniform jitter [0, jitter] added to base
+ *   MOCK_LLM_BILLING_FAIL_PCT=0     percent of calls that throw a billing
+ *                                   error string the runtime classifier
+ *                                   recognizes (used to exercise the LLM
+ *                                   health-gate without burning real credits)
+ *
+ * The mock implements the SDK `LlmClient` interface verbatim. Tools are not
+ * exercised - capacity tests focus on the request/response cycle, not on
+ * multi-round tool-use loops.
+ */
+import type { CompletionResult, LlmClient, ToolDef, ToolResult } from '@elisym/sdk/skills';
+
+function parseEnvNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function delayMs(): number {
+  // Re-read env on each call so test runs (and live edits during dev) take
+  // effect without restarting the process. The mock is dev-only; per-call
+  // env read overhead is negligible.
+  return (
+    parseEnvNumber('MOCK_LLM_LATENCY_MS', 0) +
+    Math.random() * parseEnvNumber('MOCK_LLM_JITTER_MS', 200)
+  );
+}
+
+function maybeThrowBilling(): void {
+  const pct = parseEnvNumber('MOCK_LLM_BILLING_FAIL_PCT', 0);
+  if (pct <= 0) {
+    return;
+  }
+  if (Math.random() * 100 < pct) {
+    // String shape mirrors the real provider error format the runtime
+    // classifier (runtime.ts BILLING_BODY_MARKERS) keys on.
+    throw new Error(
+      'Mock provider API error: 402 credit balance exhausted (MOCK_LLM_BILLING_FAIL_PCT)',
+    );
+  }
+}
+
+function syntheticReply(systemPrompt: string, userInput: string): string {
+  const promptHead = systemPrompt.slice(0, 60).replace(/\s+/g, ' ').trim();
+  const inputHead = userInput.slice(0, 80).replace(/\s+/g, ' ').trim();
+  return `MOCK_LLM reply | system="${promptHead}" | input="${inputHead}"`;
+}
+
+class MockLlmClient implements LlmClient {
+  async complete(systemPrompt: string, userInput: string, signal?: AbortSignal): Promise<string> {
+    await sleepRespectingSignal(delayMs(), signal);
+    maybeThrowBilling();
+    return syntheticReply(systemPrompt, userInput);
+  }
+
+  async completeWithTools(
+    systemPrompt: string,
+    messages: unknown[],
+    _tools: ToolDef[],
+    signal?: AbortSignal,
+  ): Promise<CompletionResult> {
+    await sleepRespectingSignal(delayMs(), signal);
+    maybeThrowBilling();
+    const lastMessage = messages.at(-1);
+    const inputText =
+      typeof lastMessage === 'string'
+        ? lastMessage
+        : JSON.stringify(lastMessage ?? '').slice(0, 200);
+    return { type: 'text', text: syntheticReply(systemPrompt, inputText) };
+  }
+
+  formatToolResultMessages(_results: ToolResult[]): unknown[] {
+    return [];
+  }
+}
+
+function sleepRespectingSignal(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('aborted'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      cleanup();
+      reject(new Error('aborted'));
+    };
+    function cleanup() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export function isMockLlmEnabled(): boolean {
+  return process.env.MOCK_LLM === '1' || process.env.MOCK_LLM?.toLowerCase() === 'true';
+}
+
+/**
+ * Throw if MOCK_LLM is enabled in a production deployment. Called from
+ * `cmdStart` before any state is mutated so a misconfig fails fast and
+ * loud instead of silently serving fake answers in front of paying users.
+ */
+export function refuseMockLlmInProduction(): void {
+  if (isMockLlmEnabled() && process.env.NODE_ENV === 'production') {
+    throw new Error('MOCK_LLM=1 is not allowed in NODE_ENV=production. Unset one or the other.');
+  }
+}
+
+export function createMockLlmClient(): LlmClient {
+  return new MockLlmClient();
+}

--- a/packages/cli/src/metrics.ts
+++ b/packages/cli/src/metrics.ts
@@ -1,0 +1,284 @@
+/**
+ * Prometheus metrics exporter for the provider runtime.
+ *
+ * Off by default. Activated via `elisym start <name> --metrics-port <n>`.
+ * The exporter is a small node:http server returning text/plain prom-client
+ * output at GET /metrics. Anything else returns 404. Bind address is loopback
+ * unless the operator overrides via ELISYM_METRICS_HOST.
+ *
+ * The intended use is local capacity testing (see packages/perf). The exporter
+ * adds no overhead and changes no behaviour when the flag is absent.
+ */
+import { createServer, type Server } from 'node:http';
+import type { LlmHealthMonitor } from '@elisym/sdk/llm-health';
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import type { AgentRuntime, RuntimeCallbacks } from './runtime.js';
+
+const NAMESPACE = 'elisym';
+
+export interface MetricsContext {
+  registry: Registry;
+  jobsReceived: Counter<'capability'>;
+  jobsCompleted: Counter<'capability' | 'result'>;
+  jobsInFlight: Gauge;
+  jobsPending: Gauge;
+  jobDurationSeconds: Histogram<'capability' | 'result'>;
+  paymentsReceived: Counter;
+  paymentAmountLamports: Histogram;
+  healthGate: Gauge<'provider' | 'model' | 'status'>;
+}
+
+export function createMetricsContext(): MetricsContext {
+  const registry = new Registry();
+  registry.setDefaultLabels({ service: 'elisym-cli' });
+  collectDefaultMetrics({ register: registry, prefix: `${NAMESPACE}_process_` });
+
+  const jobsReceived = new Counter({
+    name: `${NAMESPACE}_jobs_received_total`,
+    help: 'Total job requests received by the provider runtime, by skill capability.',
+    labelNames: ['capability'],
+    registers: [registry],
+  });
+
+  const jobsCompleted = new Counter({
+    name: `${NAMESPACE}_jobs_completed_total`,
+    help: 'Total jobs that left the runtime, by capability and outcome (ok|error).',
+    labelNames: ['capability', 'result'],
+    registers: [registry],
+  });
+
+  const jobsInFlight = new Gauge({
+    name: `${NAMESPACE}_jobs_in_flight`,
+    help: 'Jobs currently held by the runtime (executing + queued past p-limit).',
+    registers: [registry],
+  });
+
+  const jobsPending = new Gauge({
+    name: `${NAMESPACE}_jobs_pending`,
+    help: 'Jobs queued past the p-limit concurrency gate.',
+    registers: [registry],
+  });
+
+  const jobDurationSeconds = new Histogram({
+    name: `${NAMESPACE}_job_duration_seconds`,
+    help: 'Wall-clock seconds from job receipt to completion (or error).',
+    labelNames: ['capability', 'result'],
+    buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+    registers: [registry],
+  });
+
+  const paymentsReceived = new Counter({
+    name: `${NAMESPACE}_payments_received_total`,
+    help: 'Total payments confirmed for jobs.',
+    registers: [registry],
+  });
+
+  const paymentAmountLamports = new Histogram({
+    name: `${NAMESPACE}_payment_amount_lamports`,
+    help: 'Net payment amount per job in lamports (or token base units).',
+    buckets: [
+      1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 10_000_000_000,
+    ],
+    registers: [registry],
+  });
+
+  const healthGate = new Gauge({
+    name: `${NAMESPACE}_health_gate_state`,
+    help: 'LLM health-gate state per (provider, model). 1 if status matches the label, else 0.',
+    labelNames: ['provider', 'model', 'status'],
+    registers: [registry],
+  });
+
+  return {
+    registry,
+    jobsReceived,
+    jobsCompleted,
+    jobsInFlight,
+    jobsPending,
+    jobDurationSeconds,
+    paymentsReceived,
+    paymentAmountLamports,
+    healthGate,
+  };
+}
+
+/**
+ * Wrap an existing RuntimeCallbacks set to fan out to prom-client metrics
+ * before delegating. The wrapper is non-throwing: instrumentation errors are
+ * swallowed so they cannot poison the job loop.
+ */
+export function instrumentCallbacks(
+  ctx: MetricsContext,
+  inner: RuntimeCallbacks = {},
+): RuntimeCallbacks {
+  const startTimes = new Map<string, { startMs: number; capability: string }>();
+
+  const capabilityOf = (job: { tags: string[] }): string => {
+    for (const tag of job.tags) {
+      if (typeof tag === 'string' && tag !== 'elisym') {
+        return tag;
+      }
+    }
+    return 'unknown';
+  };
+
+  return {
+    onJobReceived(job) {
+      try {
+        const capability = capabilityOf(job);
+        startTimes.set(job.jobId, { startMs: Date.now(), capability });
+        ctx.jobsReceived.inc({ capability });
+      } catch {
+        // metrics must never throw; ignore.
+      }
+      inner.onJobReceived?.(job);
+    },
+    onJobCompleted(jobId, result) {
+      try {
+        const start = startTimes.get(jobId);
+        startTimes.delete(jobId);
+        const capability = start?.capability ?? 'unknown';
+        const elapsedSeconds = start ? (Date.now() - start.startMs) / 1000 : 0;
+        ctx.jobsCompleted.inc({ capability, result: 'ok' });
+        ctx.jobDurationSeconds.observe({ capability, result: 'ok' }, elapsedSeconds);
+      } catch {
+        // ignore
+      }
+      inner.onJobCompleted?.(jobId, result);
+    },
+    onJobError(jobId, error) {
+      try {
+        const start = startTimes.get(jobId);
+        startTimes.delete(jobId);
+        const capability = start?.capability ?? 'unknown';
+        const elapsedSeconds = start ? (Date.now() - start.startMs) / 1000 : 0;
+        ctx.jobsCompleted.inc({ capability, result: 'error' });
+        ctx.jobDurationSeconds.observe({ capability, result: 'error' }, elapsedSeconds);
+      } catch {
+        // ignore
+      }
+      inner.onJobError?.(jobId, error);
+    },
+    onPaymentReceived(jobId, netAmount) {
+      try {
+        ctx.paymentsReceived.inc();
+        if (Number.isFinite(netAmount) && netAmount >= 0) {
+          ctx.paymentAmountLamports.observe(netAmount);
+        }
+      } catch {
+        // ignore
+      }
+      inner.onPaymentReceived?.(jobId, netAmount);
+    },
+    onLog: inner.onLog,
+    onStop: inner.onStop,
+  };
+}
+
+const HEALTH_STATUSES = ['unknown', 'healthy', 'invalid', 'billing', 'unavailable'] as const;
+
+/**
+ * Periodically poll runtime + health-monitor state into the gauge metrics.
+ * Returns a stop function (idempotent).
+ */
+export function startGaugePolling(
+  ctx: MetricsContext,
+  runtime: AgentRuntime,
+  healthMonitor: LlmHealthMonitor | undefined,
+  intervalMs = 1000,
+): () => void {
+  const tick = () => {
+    try {
+      ctx.jobsInFlight.set(runtime.getInFlightCount());
+      ctx.jobsPending.set(runtime.getPendingCount());
+      if (healthMonitor) {
+        const snapshot = healthMonitor.snapshot();
+        for (const entry of snapshot) {
+          for (const status of HEALTH_STATUSES) {
+            ctx.healthGate.set(
+              { provider: entry.provider, model: entry.model, status },
+              entry.status === status ? 1 : 0,
+            );
+          }
+        }
+      }
+    } catch {
+      // ignore - metrics polling must not crash the process
+    }
+  };
+  tick();
+  const handle = setInterval(tick, intervalMs);
+  return () => clearInterval(handle);
+}
+
+export interface MetricsServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Start a tiny HTTP server exposing GET /metrics. Idempotent stop.
+ */
+export function serveMetrics(
+  ctx: MetricsContext,
+  port: number,
+  hostname?: string,
+): Promise<MetricsServer> {
+  const host = hostname ?? process.env.ELISYM_METRICS_HOST ?? '127.0.0.1';
+  const server: Server = createServer((req, res) => {
+    if (!req.url || req.method !== 'GET') {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    const path = req.url.split('?', 1)[0];
+    if (path === '/metrics') {
+      ctx.registry
+        .metrics()
+        .then((body) => {
+          res.statusCode = 200;
+          res.setHeader('Content-Type', ctx.registry.contentType);
+          res.end(body);
+        })
+        .catch((err) => {
+          res.statusCode = 500;
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+          res.end(`metrics export failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      return;
+    }
+    if (path === '/healthz') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.end('ok');
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      const url = `http://${host}:${port}/metrics`;
+      resolve({
+        url,
+        close: () =>
+          new Promise<void>((res) => {
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+export function parseMetricsPort(raw: unknown): number | undefined {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+  const parsed = Number.parseInt(String(raw), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`--metrics-port must be an integer 1..65535 (got ${String(raw)})`);
+  }
+  return parsed;
+}

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -246,6 +246,16 @@ export class AgentRuntime {
     this.maxQueueSize = config.maxQueueSize ?? config.maxConcurrentJobs * 10;
   }
 
+  /** Jobs currently being processed (executing or queued past p-limit). */
+  getInFlightCount(): number {
+    return this.inFlight.size;
+  }
+
+  /** Jobs queued past the p-limit concurrency gate. */
+  getPendingCount(): number {
+    return this.pending;
+  }
+
   /**
    * Inspect an error thrown by `skill.execute()` and, when it carries a
    * billing/invalid signal from the LLM provider, flip the matching

--- a/packages/cli/tests/metrics.test.ts
+++ b/packages/cli/tests/metrics.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createMetricsContext,
+  instrumentCallbacks,
+  parseMetricsPort,
+  serveMetrics,
+  startGaugePolling,
+  type MetricsServer,
+} from '../src/metrics.js';
+import type { IncomingJob } from '../src/transport/nostr.js';
+
+const fakeJob = (jobId: string, capability: string): IncomingJob =>
+  ({
+    jobId,
+    tags: [capability, 'elisym'],
+    input: 'unused',
+    customerPubkey: 'pk',
+    encrypted: false,
+  }) as unknown as IncomingJob;
+
+describe('parseMetricsPort', () => {
+  it('returns undefined for missing input', () => {
+    expect(parseMetricsPort(undefined)).toBeUndefined();
+    expect(parseMetricsPort('')).toBeUndefined();
+  });
+
+  it('parses a valid port', () => {
+    expect(parseMetricsPort('9464')).toBe(9464);
+  });
+
+  it('rejects non-numeric / out-of-range', () => {
+    expect(() => parseMetricsPort('zero')).toThrow(/integer 1\.\.65535/);
+    expect(() => parseMetricsPort('0')).toThrow(/integer 1\.\.65535/);
+    expect(() => parseMetricsPort('70000')).toThrow(/integer 1\.\.65535/);
+  });
+});
+
+describe('instrumentCallbacks', () => {
+  it('increments jobs_received and jobs_completed counters', async () => {
+    const ctx = createMetricsContext();
+    const wrapped = instrumentCallbacks(ctx);
+
+    wrapped.onJobReceived?.(fakeJob('job-1', 'translate'));
+    wrapped.onJobReceived?.(fakeJob('job-2', 'translate'));
+    wrapped.onJobCompleted?.('job-1', 'ok');
+    wrapped.onJobError?.('job-2', 'boom');
+
+    const text = await ctx.registry.metrics();
+    expect(text).toMatch(/elisym_jobs_received_total\{[^}]*capability="translate"[^}]*\}\s+2/);
+    expect(text).toMatch(
+      /elisym_jobs_completed_total\{[^}]*capability="translate"[^}]*result="ok"[^}]*\}\s+1/,
+    );
+    expect(text).toMatch(
+      /elisym_jobs_completed_total\{[^}]*capability="translate"[^}]*result="error"[^}]*\}\s+1/,
+    );
+  });
+
+  it('forwards callbacks to the inner handler', () => {
+    const ctx = createMetricsContext();
+    const calls: string[] = [];
+    const wrapped = instrumentCallbacks(ctx, {
+      onJobReceived: (job) => calls.push(`recv:${job.jobId}`),
+      onJobCompleted: (id) => calls.push(`done:${id}`),
+      onPaymentReceived: (id, amt) => calls.push(`pay:${id}:${amt}`),
+    });
+
+    wrapped.onJobReceived?.(fakeJob('a', 'x'));
+    wrapped.onJobCompleted?.('a', 'ok');
+    wrapped.onPaymentReceived?.('a', 1234);
+
+    expect(calls).toEqual(['recv:a', 'done:a', 'pay:a:1234']);
+  });
+
+  it('records job duration histograms with capability label', async () => {
+    const ctx = createMetricsContext();
+    const wrapped = instrumentCallbacks(ctx);
+
+    wrapped.onJobReceived?.(fakeJob('dur-1', 'summarize'));
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    wrapped.onJobCompleted?.('dur-1', 'ok');
+
+    const text = await ctx.registry.metrics();
+    expect(text).toMatch(/elisym_job_duration_seconds_count\{[^}]*capability="summarize"/);
+  });
+});
+
+describe('startGaugePolling', () => {
+  it('reads inFlight and pending counts from the runtime', async () => {
+    const ctx = createMetricsContext();
+    const fakeRuntime = {
+      getInFlightCount: () => 4,
+      getPendingCount: () => 7,
+    } as { getInFlightCount: () => number; getPendingCount: () => number };
+    // @ts-expect-error - structural shim is enough for the gauge polling
+    const stop = startGaugePolling(ctx, fakeRuntime, undefined, 50);
+    await new Promise((r) => setTimeout(r, 80));
+    stop();
+
+    const text = await ctx.registry.metrics();
+    expect(text).toMatch(/elisym_jobs_in_flight\{[^}]*\}\s+4/);
+    expect(text).toMatch(/elisym_jobs_pending\{[^}]*\}\s+7/);
+  });
+});
+
+describe('serveMetrics', () => {
+  let handle: MetricsServer | undefined;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close();
+      handle = undefined;
+    }
+  });
+
+  it('responds to GET /metrics with prom-client text', async () => {
+    const ctx = createMetricsContext();
+    handle = await serveMetrics(ctx, 0); // ephemeral port
+    // serveMetrics returns the configured port in url; with port=0 the actual
+    // port comes from the OS, so skip url assertion and probe via the bound
+    // address. node:http listen on 0 uses an OS-assigned port; recover it
+    // by re-resolving the url fragment.
+    // Workaround: bind a known port instead, retrying if busy.
+    await handle.close();
+
+    const port = 19464 + Math.floor(Math.random() * 1000);
+    handle = await serveMetrics(ctx, port);
+    const res = await fetch(handle.url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type') ?? '').toMatch(/text\/plain/);
+    const body = await res.text();
+    expect(body).toMatch(/^# HELP elisym_/m);
+
+    const health = await fetch(`http://127.0.0.1:${port}/healthz`);
+    expect(health.status).toBe(200);
+    expect(await health.text()).toBe('ok');
+
+    const missing = await fetch(`http://127.0.0.1:${port}/nope`);
+    expect(missing.status).toBe(404);
+  });
+});

--- a/packages/cli/tests/mock-llm.test.ts
+++ b/packages/cli/tests/mock-llm.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createLlmClient } from '../src/llm';
+import { createMockLlmClient, isMockLlmEnabled, refuseMockLlmInProduction } from '../src/llm/mock';
+
+describe('mock LLM client', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      MOCK_LLM: process.env.MOCK_LLM,
+      MOCK_LLM_LATENCY_MS: process.env.MOCK_LLM_LATENCY_MS,
+      MOCK_LLM_JITTER_MS: process.env.MOCK_LLM_JITTER_MS,
+      MOCK_LLM_BILLING_FAIL_PCT: process.env.MOCK_LLM_BILLING_FAIL_PCT,
+      NODE_ENV: process.env.NODE_ENV,
+    };
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  it('isMockLlmEnabled honours MOCK_LLM=1 and MOCK_LLM=true', () => {
+    delete process.env.MOCK_LLM;
+    expect(isMockLlmEnabled()).toBe(false);
+    process.env.MOCK_LLM = '1';
+    expect(isMockLlmEnabled()).toBe(true);
+    process.env.MOCK_LLM = 'true';
+    expect(isMockLlmEnabled()).toBe(true);
+    process.env.MOCK_LLM = 'TRUE';
+    expect(isMockLlmEnabled()).toBe(true);
+    process.env.MOCK_LLM = '0';
+    expect(isMockLlmEnabled()).toBe(false);
+  });
+
+  it('refuseMockLlmInProduction throws when MOCK_LLM=1 and NODE_ENV=production', () => {
+    process.env.MOCK_LLM = '1';
+    process.env.NODE_ENV = 'production';
+    expect(() => refuseMockLlmInProduction()).toThrow(/not allowed in NODE_ENV=production/);
+  });
+
+  it('refuseMockLlmInProduction is a no-op outside production', () => {
+    process.env.MOCK_LLM = '1';
+    delete process.env.NODE_ENV;
+    expect(() => refuseMockLlmInProduction()).not.toThrow();
+    process.env.NODE_ENV = 'development';
+    expect(() => refuseMockLlmInProduction()).not.toThrow();
+  });
+
+  it('refuseMockLlmInProduction is a no-op when MOCK_LLM is unset', () => {
+    delete process.env.MOCK_LLM;
+    process.env.NODE_ENV = 'production';
+    expect(() => refuseMockLlmInProduction()).not.toThrow();
+  });
+
+  it('createMockLlmClient.complete returns a synthetic reply that includes input', async () => {
+    process.env.MOCK_LLM_JITTER_MS = '0';
+    const client = createMockLlmClient();
+    const reply = await client.complete('You are a helpful test agent.', 'translate hello world');
+    expect(reply).toMatch(/MOCK_LLM reply/);
+    expect(reply).toMatch(/translate hello world/);
+  });
+
+  it('createMockLlmClient honours BILLING_FAIL_PCT=100 by throwing', async () => {
+    process.env.MOCK_LLM_BILLING_FAIL_PCT = '100';
+    process.env.MOCK_LLM_JITTER_MS = '0';
+    const client = createMockLlmClient();
+    await expect(client.complete('sys', 'input')).rejects.toThrow(/credit balance|billing/i);
+  });
+
+  it('createLlmClient returns the mock when MOCK_LLM is enabled', async () => {
+    process.env.MOCK_LLM = '1';
+    process.env.MOCK_LLM_JITTER_MS = '0';
+    const client = createLlmClient({
+      provider: 'anthropic',
+      apiKey: 'sk-fake',
+      model: 'claude-3-5-haiku-20241022',
+      maxTokens: 1024,
+    });
+    const reply = await client.complete('sys', 'hello');
+    expect(reply).toMatch(/MOCK_LLM reply/);
+  });
+
+  it('createMockLlmClient.completeWithTools returns text result regardless of tools', async () => {
+    process.env.MOCK_LLM_JITTER_MS = '0';
+    const client = createMockLlmClient();
+    const result = await client.completeWithTools('sys', ['user message'], [], undefined);
+    expect(result.type).toBe('text');
+  });
+});

--- a/packages/perf/.gitignore
+++ b/packages/perf/.gitignore
@@ -1,0 +1,4 @@
+k6/reports/*
+!k6/reports/.gitkeep
+.k6-bin/
+*.local.yml

--- a/packages/perf/README.md
+++ b/packages/perf/README.md
@@ -1,0 +1,258 @@
+# @elisym/perf
+
+Local capacity tests for the elisym stack. Answers four scaling questions:
+
+1. **Q1** How many agents can stay online before discovery degrades?
+2. **Q2** How fast does an end user see search results in the web app?
+3. **Q3** How fast is `discover_agents` in MCP?
+4. **Q4** How many concurrent jobs does one provider hold?
+
+Plus a fifth bonus scenario `e2e_steady_state` that runs all of them simultaneously to surface drift / leaks.
+
+This package is **private** (`"private": true`). It is not published, not part of `bun qa`, and runs only on a developer machine.
+
+## Prerequisites
+
+- Docker + docker compose v2 (strfry + prometheus + grafana stack)
+- Bun 1.3.11+ (already required by the monorepo)
+- `k6` binary on PATH - macOS: `brew install k6`. Linux: see https://grafana.com/docs/k6/latest/set-up/install-k6/.
+- For Q4 + Q5 only: a built `@elisym/cli` (`bun run build --filter=@elisym/cli`) and an elisym agent created via `elisym init`.
+- For Q3 only: a built `@elisym/mcp` and the same agent.
+- Solana CLI on PATH if you plan to run scenarios that exercise on-chain payments (Phase 7+, currently optional).
+
+## Layout
+
+```
+docker/                docker compose stack: strfry, prometheus, grafana
+bridge/                bun + hono HTTP wrapper around @elisym/sdk
+mcp-runner/            (deferred; mcp driver lives inside bridge/)
+k6/lib/                shared k6 helpers (env, nostr ws, solana-rpc, stats)
+k6/scenarios/          one file per scenario; named after the question it answers
+k6/fixtures/           gitignored; pre-signed event fixtures generated on demand
+k6/reports/            gitignored; per-run JSON + HTML output
+scripts/               stack-up / stack-down / run / start-validator wrappers
+skills/perf-translate/ sample SKILL.md to copy into your perf agent
+```
+
+## Scenarios at a glance
+
+| Scenario                 | Question        | Pre-conditions                                          |
+| ------------------------ | --------------- | ------------------------------------------------------- |
+| `relay_publish`          | infra baseline  | stack up                                                |
+| `solana_rpc_burst`       | RPC baseline    | stack up + `solana-test-validator` running              |
+| `protocol_config_cache`  | RPC + SDK cache | stack + validator + bridge                              |
+| `discover_via_bridge`    | sanity smoke    | stack + bridge                                          |
+| `agent_fleet_scale`      | Q1              | stack + bridge                                          |
+| `relay_subscribe_fanout` | Q2 diagnosis    | stack                                                   |
+| `web_discovery_latency`  | Q2              | stack + bridge + a fleet (or run agent_fleet_scale)     |
+| `mcp_discovery_latency`  | Q3              | stack + bridge + elisym-mcp on PATH + agent             |
+| `provider_saturation`    | Q4              | stack + bridge + provider on host with `--metrics-port` |
+| `e2e_steady_state`       | Q5 composite    | everything above                                        |
+
+## Quick start (Q1 fleet sweep, mock-everything)
+
+Three terminals:
+
+```bash
+# Terminal 1: infra stack
+bun run perf:up
+
+# Terminal 2: bridge
+RELAYS=ws://localhost:7777 bun run perf:bridge
+
+# Terminal 3: scenario
+bun run perf:run agent_fleet_scale
+open http://localhost:3000   # grafana, dashboard "elisym - relay & discovery"
+```
+
+Stop when done:
+
+```bash
+# Ctrl+C terminal 2
+bun run perf:down
+```
+
+## Full walk-through to answer all four questions
+
+Each step assumes you completed the previous ones unless marked optional. Numbers come out of Grafana dashboards and the per-run summary in `k6/reports/`.
+
+### 1. Boot the infra stack
+
+```bash
+bun run perf:up
+```
+
+Brings up:
+
+- `strfry` on `ws://localhost:7777` (local Nostr relay, tuned for high fanout)
+- `prometheus` on `http://localhost:9090` (scrapes itself + provider on `host.docker.internal:9464` + bridge on `host.docker.internal:3030`)
+- `grafana` on `http://localhost:3000` (anonymous viewer; admin/admin for editing)
+
+### 2. Run the bridge
+
+```bash
+RELAYS=ws://localhost:7777 bun run perf:bridge
+```
+
+Bridge exposes:
+
+- `GET  /healthz`, `GET /metrics` (prom-client)
+- `POST /discover`, `POST /stream-discover`, `POST /protocol-config`
+- `POST /fleet/resize`, `POST /fleet/stop`, `GET /fleet/info`
+- `POST /job/submit`
+- `POST /mcp/start`, `POST /mcp/call`, `POST /mcp/stop`, `GET /mcp/info`
+
+If you want the bridge to talk to a non-local relay (devnet smoke), unset `RELAYS` to use the SDK defaults (relay.damus.io, nos.lol, etc).
+
+### 3. Run the relay baseline
+
+```bash
+bun run perf:run relay_publish
+```
+
+The first invocation auto-generates a fixture of 5000 pre-signed kind:5100 events via `scripts/generate-events.ts` (writes to `k6/fixtures/events-5100.json`). Subsequent runs reuse it; delete the file to regenerate.
+
+Read off `relay_ok_latency_ms` p95/p99 in the run summary. This is the floor; nothing else can be faster than this on the same box.
+
+### 4. (Optional) Solana baselines
+
+Boot `solana-test-validator` (separate terminal):
+
+```bash
+bun run program:build           # produces target/deploy/elisym_config.so
+bun run perf:validator          # starts test-validator with the program loaded
+```
+
+Then:
+
+```bash
+bun run perf:run solana_rpc_burst
+bun run perf:run protocol_config_cache
+```
+
+Skip these for Q1 / Q2 / Q3 / Q4 - they are foundation runs, not headline.
+
+### 5. Q1: agent fleet scale
+
+```bash
+bun run perf:run agent_fleet_scale
+```
+
+Sweep is `0 -> 10 -> 100 -> 500 -> 1000 -> 2500 -> 5000` synthetic agents. At each step, 10 discovery samples are taken. Read the curve in Grafana dashboard **elisym - relay & discovery**.
+
+The "knee" is the fleet size at which `discover_call_ms{quantile="0.95"}` jumps. That number tells you how many online agents your local stack can carry before discovery latency degrades.
+
+Tweak via env: `FLEET_SIZES=0,500,5000 SAMPLES=20 PROPAGATION_S=10`.
+
+### 6. Q2: web discovery latency
+
+Pre-condition: a fleet exists (run `agent_fleet_scale` first, or POST to `/fleet/resize` manually).
+
+```bash
+# manual fleet bootstrap if needed
+curl -X POST localhost:3030/fleet/resize -H 'content-type: application/json' \
+  -d '{"size": 500}'
+
+bun run perf:run web_discovery_latency
+```
+
+Reads off:
+
+- `ttf_first_card_ms` - time-to-first-card
+- `ttn_n_cards_ms` - time-to-N-cards (default N=10)
+- `tte_eose_ms` - time-to-EOSE
+- `ttc_complete_ms` - time-to-complete (after enrichment)
+
+Diagnose with `relay_subscribe_fanout` if numbers look unexpectedly high.
+
+### 7. Q3: MCP discovery latency
+
+Pre-conditions:
+
+- `@elisym/mcp` built (`bun run build --filter=@elisym/mcp`) and `elisym-mcp` on PATH (link with `bun link`, or use absolute path via `MCP_COMMAND`).
+- An elisym agent created: `elisym init perf-agent --local` (run from inside the monorepo for `--local`).
+
+```bash
+MCP_AGENT=perf-agent bun run perf:run mcp_discovery_latency
+```
+
+Sweeps `0 -> 50 -> 500 -> 2000` agents on the relay. Records `mcp_call_ms` p50/p95/p99 per fleet size. This is the latency a Claude / Cursor / Windsurf user sees on `discover_agents`.
+
+### 8. Q4: provider saturation
+
+Pre-conditions:
+
+- Same `perf-agent` from Q3.
+- Copy the sample skill into the agent: `cp -r packages/perf/skills/perf-translate ~/.elisym/perf-agent/skills/` (or your project-local `.elisym/perf-agent/skills/`).
+- Edit `~/.elisym/perf-agent/elisym.yaml` to set `relays: [ws://localhost:7777]` so the provider talks to local strfry, not public.
+- Provider running on host with mock LLM and metrics enabled:
+
+```bash
+MOCK_LLM=1 MOCK_LLM_JITTER_MS=200 \
+  elisym start perf-agent --metrics-port 9464
+```
+
+Then:
+
+```bash
+bun run perf:run provider_saturation
+```
+
+Submission RPS ramps `1 -> 5 -> 15 -> 30 -> 60` per second across stages. Open Grafana dashboard **elisym - provider saturation** and watch:
+
+- `elisym_jobs_in_flight` pegging at 10 (= `MAX_CONCURRENT_JOBS`)
+- `elisym_jobs_pending` climbing once you exceed sustainable throughput
+- `histogram_quantile(0.95, sum(rate(elisym_job_duration_seconds_bucket[1m])))` p95 inflection
+
+The first stage where `pending` climbs without bound is the provider's roof on this hardware with mock LLM. Real LLM is bound by Anthropic / OpenAI rate limits; rerun with `MOCK_LLM` unset and a paid API key to find that ceiling - **expect to burn credits**.
+
+### 9. Q5: composite steady-state
+
+```bash
+bun run perf:run e2e_steady_state
+```
+
+Holds 500 agents online + 5 discovery RPS + 1 job/min for 10 min. Open dashboard **elisym - end-to-end steady state**. Watch for: success-rate drift > 5%, monotonically growing latency, leaking `jobs_pending`.
+
+Tunables: `SUSTAINED_AGENTS`, `DISCOVERY_RPS`, `JOB_RPS`, `DURATION_MIN`.
+
+## Grafana dashboards
+
+Auto-provisioned in Grafana under folder `elisym-perf`:
+
+| File            | Story                                                       |
+| --------------- | ----------------------------------------------------------- |
+| `k6.json`       | Cross-scenario overview (VUs, RPS, p50/p95/p99, errors).    |
+| `relay.json`    | Q1 - discovery latency vs fleet size.                       |
+| `provider.json` | Q4 - jobs in flight, throughput, job duration, health gate. |
+| `e2e.json`      | Q5 - composite throughput + drift in success rates.         |
+
+The reports directory (`k6/reports/`) holds per-run JSON + a static HTML summary that mirrors the k6 `textSummary` output.
+
+## Observed numbers
+
+Filled in as runs land. Format: hardware + scenario + headline metric. Re-record after major SDK changes.
+
+```
+2026-XX-XX  M1 Pro 32GB  agent_fleet_scale  knee at fleet=____ (p95 jumps from ____ms to ____ms)
+2026-XX-XX  M1 Pro 32GB  web_discovery_latency  ttf p95=____ms ttn(10) p95=____ms ttc p95=____ms (fleet=500)
+2026-XX-XX  M1 Pro 32GB  mcp_discovery_latency  mcp_call p95=____ms (fleet=500)
+2026-XX-XX  M1 Pro 32GB  provider_saturation  sustained ____ jobs/sec (mock LLM, jitter=200ms)
+```
+
+## Troubleshooting
+
+- **`k6: command not found`** - install via `brew install k6` (macOS) or download from grafana.com.
+- **strfry container exits immediately** - `docker compose -f packages/perf/docker/docker-compose.yml logs strfry`. Usually a `strfry.conf` typo.
+- **Grafana shows no provider/bridge data** - those are scraped from `host.docker.internal:9464` and `:3030`. On Linux you may need to add `extra_hosts: ["host.docker.internal:host-gateway"]` to the docker-compose services that need to reach the host (Docker Desktop maps it automatically on macOS).
+- **`/job/submit` fails with rate-limit** - the bridge identity pool defaults to 128 keys; if you exceed 20 jobs per identity in a 10-min window the provider's per-customer limiter rejects. Increase via `IDENTITY_POOL_SIZE=512 bun run perf:bridge`.
+- **`provider_saturation` shows zero on the dashboards** - confirm provider is reading from local strfry: `relays: [ws://localhost:7777]` in the agent's elisym.yaml. Confirm `--metrics-port 9464` is actually bound.
+- **`mcp_discovery_latency` `mcp/start failed`** - the bridge spawns `elisym-mcp` from `PATH`. If you have a workspace build but no global symlink, set `MCP_COMMAND=/absolute/path/to/dist/index.js` (and ensure it has executable bits).
+- **fixture rejected by relay** - regenerate via `bun packages/perf/scripts/generate-events.ts --kind 5100 --count 5000`. The fixture commits a future-skewed `created_at` policy; if your strfry rejects, check `rejectEventsNewerThanSeconds` in `strfry.conf`.
+
+## Deferred / future work
+
+- **`payment_full_flow`** end-to-end on test-validator: needs funded keypairs and the elisym-config program deployed; covered by `program:build` + `perf:validator` plumbing already in place.
+- **Browser-side warm-cache scenario** (`web_browser_smoke.js`): k6 browser against `vite preview` of `packages/app`. Optional, only meaningful if measuring real IndexedDB cache hits matters to you.
+- **Provider recovery scenario** (`provider_recovery.js`): kill -9 the provider mid-run, verify ledger replays paid-but-not-delivered jobs.
+- **Real LLM ceiling** (`llm_real.js`): rerun `provider_saturation` without `MOCK_LLM` to find the Anthropic / OpenAI rate-limit ceiling. Costs real money - run intentionally.

--- a/packages/perf/README.md
+++ b/packages/perf/README.md
@@ -234,10 +234,11 @@ The reports directory (`k6/reports/`) holds per-run JSON + a static HTML summary
 Filled in as runs land. Format: hardware + scenario + headline metric. Re-record after major SDK changes.
 
 ```
-2026-XX-XX  M1 Pro 32GB  agent_fleet_scale  knee at fleet=____ (p95 jumps from ____ms to ____ms)
-2026-XX-XX  M1 Pro 32GB  web_discovery_latency  ttf p95=____ms ttn(10) p95=____ms ttc p95=____ms (fleet=500)
-2026-XX-XX  M1 Pro 32GB  mcp_discovery_latency  mcp_call p95=____ms (fleet=500)
-2026-XX-XX  M1 Pro 32GB  provider_saturation  sustained ____ jobs/sec (mock LLM, jitter=200ms)
+2026-05-21  M3 Pro 18GB  relay_publish  accept=100% (53833/53833), ok_latency p50=1ms p95=2ms p99=2ms, peak ~1000 evt/s @ 50 VUs
+2026-05-21  M3 Pro 18GB  agent_fleet_scale  clean sweep, per-call by fleet: 0=0ms, 10=20ms, 100=100ms, 500=450ms, 1000=850ms, 2500=2.5s, 5000=5.5s; knee between 1000-2500, p99 across all=5.67s (limit=6000)
+2026-05-21  M3 Pro 18GB  web_discovery_latency  fleet=5000, 1 VU: ttf p50=3ms p95=4.6ms, ttn(10) p95=13ms, EOSE p95=4.23s, ttc(enrichment) p95=5.28s, success=100%. Production-grade UX at this scale
+2026-05-21  M3 Pro 18GB  mcp_discovery_latency  fleet sweep 0/50/500/2000: mcp_call p50=6.88s p95=8.82s p99=8.91s, success=100%. Flat floor ~6-7s regardless of fleet (enrichment+querySync timeout, not search itself); slow for chat UX, fix = lazy enrichment + pagination
+2026-05-21  M3 Pro 18GB  provider_saturation  MOCK_LLM jitter=200ms, rate-limits bypassed via env: sustained ~19 jobs/sec completed, 100% ok (2848/2848), 14% loss in Nostr publish/delivery path (3327 submitted, 2848 reached provider). Job duration incl. queue p50=250ms p95=1s p99=2s. Real LLM would cap at ~5-10 jobs/sec per provider
 ```
 
 ## Troubleshooting

--- a/packages/perf/bridge/src/fleet.ts
+++ b/packages/perf/bridge/src/fleet.ts
@@ -1,0 +1,216 @@
+/**
+ * Agent fleet simulator - synthetic NIP-89 announcements + ephemeral pings.
+ *
+ * Goal: load the relay with N "online" elisym agents so discovery scenarios
+ * can measure how `fetchAgents` latency grows with fleet size. Each synthetic
+ * agent publishes:
+ *
+ *   - one kind:31990 (NIP-89 app handler) on start, tagged
+ *     `["t","elisym"]` + capability tag, marking it discoverable.
+ *   - one kind:20200 (ephemeral ping) every `pingIntervalMs`, so it looks
+ *     "live" instead of stale-cached.
+ *
+ * Re-publishes the NIP-89 announcement every `republishMs` to defend against
+ * relay GC of older parameterized-replaceable events under churn. The fleet
+ * uses a single shared SimplePool so all events fan out across the configured
+ * relay list.
+ *
+ * Scale up: only the new keys publish. Scale down: ping timers cancelled and
+ * keypairs zeroed out (we rely on relay-side TTL for the NIP-89 cards because
+ * NIP-09 deletion would itself add load we don't want to measure here).
+ */
+import { SimplePool, finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools';
+import type { Event } from 'nostr-tools';
+
+interface FleetMember {
+  sk: Uint8Array;
+  pk: string;
+  pingTimer: ReturnType<typeof setInterval> | null;
+}
+
+export interface FleetConfig {
+  capability: string;
+  relays: string[];
+  pingIntervalMs: number;
+  republishMs: number;
+}
+
+export interface FleetSnapshot {
+  size: number;
+  capability: string;
+  relays: string[];
+  pingIntervalMs: number;
+  republishMs: number;
+  publishedAnnounceTotal: number;
+  publishedPingTotal: number;
+}
+
+export class FleetSimulator {
+  private pool = new SimplePool();
+  private members: FleetMember[] = [];
+  private republishTimer: ReturnType<typeof setInterval> | null = null;
+  private publishedAnnounceTotal = 0;
+  private publishedPingTotal = 0;
+  private config: FleetConfig;
+
+  constructor(config: FleetConfig) {
+    this.config = config;
+  }
+
+  size(): number {
+    return this.members.length;
+  }
+
+  snapshot(): FleetSnapshot {
+    return {
+      size: this.size(),
+      capability: this.config.capability,
+      relays: this.config.relays,
+      pingIntervalMs: this.config.pingIntervalMs,
+      republishMs: this.config.republishMs,
+      publishedAnnounceTotal: this.publishedAnnounceTotal,
+      publishedPingTotal: this.publishedPingTotal,
+    };
+  }
+
+  /** Set the fleet to exactly `target` members, growing or shrinking as needed. */
+  async resize(target: number): Promise<FleetSnapshot> {
+    if (target < 0 || !Number.isInteger(target)) {
+      throw new Error('fleet target must be a non-negative integer');
+    }
+    if (target > this.members.length) {
+      await this.grow(target - this.members.length);
+    } else if (target < this.members.length) {
+      this.shrink(this.members.length - target);
+    }
+    if (this.members.length > 0 && !this.republishTimer) {
+      this.startRepublishTimer();
+    }
+    if (this.members.length === 0 && this.republishTimer) {
+      clearInterval(this.republishTimer);
+      this.republishTimer = null;
+    }
+    return this.snapshot();
+  }
+
+  stop(): FleetSnapshot {
+    this.shrink(this.members.length);
+    if (this.republishTimer) {
+      clearInterval(this.republishTimer);
+      this.republishTimer = null;
+    }
+    this.pool.close(this.config.relays);
+    return this.snapshot();
+  }
+
+  private async grow(delta: number): Promise<void> {
+    const fresh: FleetMember[] = [];
+    for (let i = 0; i < delta; i++) {
+      const sk = generateSecretKey();
+      const pk = getPublicKey(sk);
+      fresh.push({ sk, pk, pingTimer: null });
+    }
+    // Publish announcements first; pings after a small splay so the relay
+    // doesn't see N synchronous pings every pingIntervalMs tick.
+    await Promise.all(fresh.map((m) => this.publishAnnounce(m)));
+    for (let i = 0; i < fresh.length; i++) {
+      const member = fresh[i];
+      const splay = Math.floor(Math.random() * this.config.pingIntervalMs);
+      member.pingTimer = setTimeout(() => {
+        this.publishPing(member).catch(() => {
+          // ignore - publish errors should not crash the fleet
+        });
+        member.pingTimer = setInterval(() => {
+          this.publishPing(member).catch(() => {
+            // ignore
+          });
+        }, this.config.pingIntervalMs);
+      }, splay) as unknown as ReturnType<typeof setInterval>;
+      this.members.push(member);
+    }
+  }
+
+  private shrink(delta: number): void {
+    for (let i = 0; i < delta; i++) {
+      const member = this.members.pop();
+      if (!member) {
+        return;
+      }
+      if (member.pingTimer) {
+        clearInterval(member.pingTimer);
+        clearTimeout(member.pingTimer as unknown as ReturnType<typeof setTimeout>);
+        member.pingTimer = null;
+      }
+      // Zero the secret key so it cannot leak.
+      member.sk.fill(0);
+    }
+  }
+
+  private startRepublishTimer(): void {
+    this.republishTimer = setInterval(() => {
+      // Stagger republishes across the fleet so we don't slam the relay.
+      for (let i = 0; i < this.members.length; i++) {
+        const member = this.members[i];
+        const delay = (i / Math.max(1, this.members.length)) * this.config.republishMs;
+        setTimeout(() => {
+          this.publishAnnounce(member).catch(() => {
+            // ignore
+          });
+        }, delay);
+      }
+    }, this.config.republishMs);
+  }
+
+  private async publishAnnounce(member: FleetMember): Promise<void> {
+    const event = this.makeAnnounce(member);
+    try {
+      await Promise.any(this.pool.publish(this.config.relays, event));
+      this.publishedAnnounceTotal++;
+    } catch {
+      // ignore - we only need at least one relay to ack
+    }
+  }
+
+  private async publishPing(member: FleetMember): Promise<void> {
+    const event = this.makePing(member);
+    try {
+      await Promise.any(this.pool.publish(this.config.relays, event));
+      this.publishedPingTotal++;
+    } catch {
+      // ignore
+    }
+  }
+
+  private makeAnnounce(member: FleetMember): Event {
+    return finalizeEvent(
+      {
+        kind: 31990,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [
+          ['d', `${this.config.capability}:${member.pk.slice(0, 8)}`],
+          ['k', '5100'],
+          ['t', this.config.capability],
+          ['t', 'elisym'],
+        ],
+        content: JSON.stringify({
+          name: `perf-agent-${member.pk.slice(0, 6)}`,
+          about: 'synthetic perf-test agent',
+          picture: '',
+        }),
+      },
+      member.sk,
+    );
+  }
+
+  private makePing(member: FleetMember): Event {
+    return finalizeEvent(
+      {
+        kind: 20200,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [['t', 'elisym']],
+        content: '',
+      },
+      member.sk,
+    );
+  }
+}

--- a/packages/perf/bridge/src/fleet.ts
+++ b/packages/perf/bridge/src/fleet.ts
@@ -112,7 +112,17 @@ export class FleetSimulator {
     }
     // Publish announcements first; pings after a small splay so the relay
     // doesn't see N synchronous pings every pingIntervalMs tick.
-    await Promise.all(fresh.map((m) => this.publishAnnounce(m)));
+    //
+    // Batch the publishes: firing 5000 publishAnnounce promises concurrently
+    // overwhelms the single WS connection inside SimplePool and loses ~70%
+    // of events silently (Promise.any resolves on socket.send-style ack
+    // before strfry's Ingester gets backpressure, so publishedAnnounceTotal
+    // lies). 100-wide batches with awaits in between preserve flow control.
+    const ANNOUNCE_BATCH = 100;
+    for (let i = 0; i < fresh.length; i += ANNOUNCE_BATCH) {
+      const batch = fresh.slice(i, i + ANNOUNCE_BATCH);
+      await Promise.all(batch.map((m) => this.publishAnnounce(m)));
+    }
     for (let i = 0; i < fresh.length; i++) {
       const member = fresh[i];
       const splay = Math.floor(Math.random() * this.config.pingIntervalMs);
@@ -182,6 +192,10 @@ export class FleetSimulator {
   }
 
   private makeAnnounce(member: FleetMember): Event {
+    // Must match @elisym/sdk's `parseCapabilityEvent` shape:
+    //   { name, description, capabilities: string[], payment?: { chain, network, address } }
+    // Missing description / capabilities => SDK silently drops the agent at
+    // parse time and discovery returns zero.
     return finalizeEvent(
       {
         kind: 31990,
@@ -194,8 +208,13 @@ export class FleetSimulator {
         ],
         content: JSON.stringify({
           name: `perf-agent-${member.pk.slice(0, 6)}`,
-          about: 'synthetic perf-test agent',
-          picture: '',
+          description: 'synthetic perf-test agent',
+          capabilities: [this.config.capability],
+          payment: {
+            chain: 'solana',
+            network: 'devnet',
+            address: member.pk,
+          },
         }),
       },
       member.sk,

--- a/packages/perf/bridge/src/identity-pool.ts
+++ b/packages/perf/bridge/src/identity-pool.ts
@@ -1,0 +1,46 @@
+/**
+ * Pool of pre-generated Nostr customer identities for k6 scenarios.
+ *
+ * Why: generating a fresh keypair per VU iteration adds ~ms of crypto overhead
+ * to every measured request. By materialising a fixed pool at bridge startup,
+ * VUs get round-robin reuse and the measurements isolate the network/SDK cost.
+ *
+ * The pool is in-memory only and is regenerated every time the bridge restarts.
+ * Phase 3+ expands this with optional Solana keypairs whose addresses are
+ * pre-funded via `solana airdrop` on test-validator.
+ */
+import { ElisymIdentity } from '@elisym/sdk';
+
+export interface PoolEntry {
+  identity: ElisymIdentity;
+  pubkeyHex: string;
+}
+
+export class IdentityPool {
+  private entries: PoolEntry[] = [];
+  private cursor = 0;
+
+  constructor(size: number) {
+    if (size <= 0) {
+      throw new Error('IdentityPool size must be > 0');
+    }
+    for (let i = 0; i < size; i++) {
+      const identity = ElisymIdentity.generate();
+      this.entries.push({ identity, pubkeyHex: identity.publicKey });
+    }
+  }
+
+  size(): number {
+    return this.entries.length;
+  }
+
+  next(): PoolEntry {
+    const entry = this.entries[this.cursor];
+    this.cursor = (this.cursor + 1) % this.entries.length;
+    return entry;
+  }
+
+  byIndex(index: number): PoolEntry {
+    return this.entries[index % this.entries.length];
+  }
+}

--- a/packages/perf/bridge/src/mcp-driver.ts
+++ b/packages/perf/bridge/src/mcp-driver.ts
@@ -1,0 +1,139 @@
+/**
+ * MCP client driver for Phase 6 (Q3 - MCP discovery latency).
+ *
+ * Spawns @elisym/mcp once via stdio and reuses the connection across many
+ * tool invocations. This mirrors how an assistant (Claude Desktop, Cursor,
+ * Windsurf) actually consumes the server - a long-lived child process over
+ * stdio with sequential JSON-RPC requests.
+ *
+ * One MCP child per bridge process. /mcp/start is idempotent (no-op if a
+ * driver is already running). /mcp/stop tears the child down.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+export interface McpStartOptions {
+  /** elisym agent name (must already exist via `elisym init`). */
+  agent: string;
+  /** Override the spawned binary; defaults to `elisym-mcp`. */
+  command?: string;
+  /** Extra args appended after the binary. */
+  args?: string[];
+  /** Extra env merged on top of process.env. */
+  env?: Record<string, string>;
+}
+
+export interface McpCallResult {
+  ok: boolean;
+  elapsedMs: number;
+  error?: string;
+  /** Whether the MCP-level result object had `isError: true`. */
+  isToolError?: boolean;
+  contentSummary?: string;
+}
+
+export class McpDriver {
+  private transport: StdioClientTransport | null = null;
+  private client: Client | null = null;
+  private startedAt = 0;
+  private callsTotal = 0;
+
+  isRunning(): boolean {
+    return this.client !== null;
+  }
+
+  uptimeMs(): number {
+    return this.startedAt === 0 ? 0 : Date.now() - this.startedAt;
+  }
+
+  totalCalls(): number {
+    return this.callsTotal;
+  }
+
+  async start(opts: McpStartOptions): Promise<void> {
+    if (this.client) {
+      return;
+    }
+    if (!opts.agent) {
+      throw new Error('mcp-driver: agent is required');
+    }
+    const command = opts.command ?? 'elisym-mcp';
+    const args = opts.args ?? [];
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ELISYM_AGENT: opts.agent,
+      ...(opts.env ?? {}),
+    };
+
+    const transport = new StdioClientTransport({ command, args, env });
+    const client = new Client(
+      { name: '@elisym/perf-bridge', version: '0.0.0' },
+      { capabilities: {} },
+    );
+    try {
+      await client.connect(transport);
+    } catch (err) {
+      // connect can spawn the child but fail the handshake; tear it down so
+      // we don't leak the process and isRunning() doesn't lie on retry.
+      try {
+        await transport.close();
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
+    this.transport = transport;
+    this.client = client;
+    this.startedAt = Date.now();
+    this.callsTotal = 0;
+  }
+
+  async stop(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch {
+        // ignore
+      }
+    }
+    if (this.transport) {
+      try {
+        await this.transport.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.client = null;
+    this.transport = null;
+    this.startedAt = 0;
+  }
+
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<McpCallResult> {
+    if (!this.client) {
+      return { ok: false, elapsedMs: 0, error: 'mcp-driver not started' };
+    }
+    const start = Date.now();
+    try {
+      const result = await this.client.callTool({ name, arguments: args });
+      this.callsTotal++;
+      const elapsedMs = Date.now() - start;
+      const isToolError = (result as { isError?: boolean })?.isError === true;
+      const content = Array.isArray((result as { content?: unknown[] }).content)
+        ? ((result as { content: unknown[] }).content as { text?: string }[])
+        : [];
+      const contentSummary = content
+        .filter((c) => typeof c?.text === 'string')
+        .map((c) => String(c.text).slice(0, 200))
+        .join(' | ')
+        .slice(0, 400);
+      return { ok: !isToolError, elapsedMs, isToolError, contentSummary };
+    } catch (err) {
+      const elapsedMs = Date.now() - start;
+      return {
+        ok: false,
+        elapsedMs,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}

--- a/packages/perf/bridge/src/metrics.ts
+++ b/packages/perf/bridge/src/metrics.ts
@@ -1,0 +1,35 @@
+/**
+ * Bridge-side prom-client metrics. Scraped by the perf-stack Prometheus.
+ */
+import { Counter, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+
+const NAMESPACE = 'elisym_bridge';
+
+export interface BridgeMetrics {
+  registry: Registry;
+  callsTotal: Counter<'route' | 'outcome'>;
+  callDuration: Histogram<'route'>;
+}
+
+export function createBridgeMetrics(): BridgeMetrics {
+  const registry = new Registry();
+  registry.setDefaultLabels({ service: 'elisym-perf-bridge' });
+  collectDefaultMetrics({ register: registry, prefix: `${NAMESPACE}_process_` });
+
+  const callsTotal = new Counter({
+    name: `${NAMESPACE}_calls_total`,
+    help: 'Bridge HTTP calls by route and outcome (ok|error).',
+    labelNames: ['route', 'outcome'],
+    registers: [registry],
+  });
+
+  const callDuration = new Histogram({
+    name: `${NAMESPACE}_call_duration_seconds`,
+    help: 'Wall-clock seconds per bridge HTTP call.',
+    labelNames: ['route'],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+    registers: [registry],
+  });
+
+  return { registry, callsTotal, callDuration };
+}

--- a/packages/perf/bridge/src/server.ts
+++ b/packages/perf/bridge/src/server.ts
@@ -1,0 +1,364 @@
+#!/usr/bin/env bun
+import {
+  ElisymClient,
+  RELAYS,
+  getProtocolConfig,
+  getProtocolProgramId,
+  type Network,
+  type ProtocolCluster,
+} from '@elisym/sdk';
+import { createSolanaRpc } from '@solana/kit';
+/**
+ * @elisym/perf bridge.
+ *
+ * Thin HTTP wrapper around @elisym/sdk so k6 scenarios can drive real SDK
+ * code paths without embedding TypeScript in k6 (k6 cannot run TS / Node
+ * imports). Also exposes a /metrics endpoint so prom-client gauges land in
+ * the perf-stack Prometheus alongside k6 metrics.
+ *
+ * Routes:
+ *   GET  /healthz                quick liveness probe
+ *   GET  /metrics                prom-client output
+ *   POST /discover               { network?, limit? } -> { agents, elapsedMs }
+ *   POST /protocol-config        { rpcUrl?, network? } -> { config, cached, elapsedMs }
+ *
+ * Run:
+ *   bun --hot packages/perf/bridge/src/server.ts
+ *   PORT=3030 RELAYS=ws://localhost:7777 RPC_URL=http://localhost:8899 ...
+ *
+ * Stop with SIGINT.
+ */
+import { Hono } from 'hono';
+import { FleetSimulator } from './fleet.js';
+import { IdentityPool } from './identity-pool.js';
+import { McpDriver } from './mcp-driver.js';
+import { createBridgeMetrics } from './metrics.js';
+
+const PORT = Number.parseInt(process.env.PORT ?? '3030', 10);
+const HOST = process.env.HOST ?? '127.0.0.1';
+const RELAYS_ENV = (process.env.RELAYS ?? '').trim();
+const RELAY_LIST = RELAYS_ENV.length > 0 ? RELAYS_ENV.split(',') : RELAYS;
+const RPC_URL = process.env.RPC_URL ?? 'http://localhost:8899';
+const NETWORK_ENV = (process.env.NETWORK ?? 'devnet') as ProtocolCluster;
+const POOL_SIZE = Number.parseInt(process.env.IDENTITY_POOL_SIZE ?? '128', 10);
+
+const metrics = createBridgeMetrics();
+const identityPool = new IdentityPool(POOL_SIZE);
+const client = new ElisymClient({ relays: RELAY_LIST });
+const rpc = createSolanaRpc(RPC_URL);
+
+let fleet: FleetSimulator | null = null;
+const mcp = new McpDriver();
+
+const app = new Hono();
+
+function instrument<T extends object>(
+  route: string,
+  fn: () => Promise<T>,
+): Promise<{ body: T; elapsedMs: number }> {
+  const startTime = Date.now();
+  const stopTimer = metrics.callDuration.startTimer({ route });
+  return fn()
+    .then((body) => {
+      const elapsedMs = Date.now() - startTime;
+      stopTimer();
+      metrics.callsTotal.inc({ route, outcome: 'ok' });
+      return { body, elapsedMs };
+    })
+    .catch((err) => {
+      stopTimer();
+      metrics.callsTotal.inc({ route, outcome: 'error' });
+      throw err;
+    });
+}
+
+app.get('/healthz', (c) => c.text('ok'));
+
+app.get('/metrics', async (c) => {
+  const body = await metrics.registry.metrics();
+  return c.text(body, 200, { 'Content-Type': metrics.registry.contentType });
+});
+
+app.post('/discover', async (c) => {
+  let payload: { network?: ProtocolCluster; limit?: number };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  const network = payload.network ?? NETWORK_ENV;
+  const limit = payload.limit;
+
+  const result = await instrument('discover', async () => {
+    // discovery's logical Network is mainnet|devnet; localnet falls back to
+    // devnet semantics since the on-chain config is the only thing that
+    // differs and we read that separately.
+    const discoveryNetwork: Network = network === 'mainnet' ? 'mainnet' : 'devnet';
+    const agents = await client.discovery.fetchAgents(discoveryNetwork, limit);
+    return {
+      count: agents.length,
+      // truncated payload: k6 only needs the count + a sample for sanity
+      sample: agents.slice(0, 3).map((a) => ({ pubkey: a.pubkey, lastSeen: a.lastSeen })),
+    };
+  });
+  return c.json({ ...result.body, elapsedMs: result.elapsedMs });
+});
+
+// ---- /stream-discover (Phase 5: Q2 web latency) ----
+//
+// Mirrors what `useAgents` / `streamAgents` does in packages/app:
+//   - subscribe to NIP-89 capability events for elisym agents
+//   - the SDK fires onAgent for every new pubkey -> "first card visible"
+//   - the SDK fires onEose when all relays have replied
+//   - background enrichment (kind:0) eventually calls onComplete with the
+//     ranked snapshot.
+//
+// k6 scenarios call this endpoint and read back a timeline of milestones,
+// turning "what does a user wait for?" into precise numbers without having
+// to render a browser.
+app.post('/stream-discover', async (c) => {
+  let payload: { network?: ProtocolCluster; timeoutMs?: number; sampleEveryN?: number };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  const network = payload.network ?? NETWORK_ENV;
+  const timeoutMs = Math.max(500, Math.min(payload.timeoutMs ?? 30_000, 120_000));
+  const sampleEveryN = Math.max(1, payload.sampleEveryN ?? 10);
+  const discoveryNetwork: Network = network === 'mainnet' ? 'mainnet' : 'devnet';
+
+  const result = await instrument('stream-discover', async () => {
+    const start = Date.now();
+    const milestones: { event: string; deltaMs: number; index?: number }[] = [];
+    let firstAgentDeltaMs: number | undefined;
+    let count = 0;
+
+    const closer = client.discovery.streamAgents(discoveryNetwork, {
+      onAgent: () => {
+        count++;
+        if (firstAgentDeltaMs === undefined) {
+          firstAgentDeltaMs = Date.now() - start;
+          milestones.push({ event: 'first-agent', deltaMs: firstAgentDeltaMs, index: 1 });
+        }
+        if (count % sampleEveryN === 0) {
+          milestones.push({ event: 'n-agents', deltaMs: Date.now() - start, index: count });
+        }
+      },
+      onEose: () => {
+        milestones.push({ event: 'eose', deltaMs: Date.now() - start });
+      },
+      onComplete: (agents) => {
+        milestones.push({
+          event: 'complete',
+          deltaMs: Date.now() - start,
+          index: agents.length,
+        });
+      },
+    });
+
+    // Wait until either onComplete fires or timeoutMs elapses, whichever first.
+    await new Promise<void>((resolve) => {
+      const interval = setInterval(() => {
+        if (milestones.some((m) => m.event === 'complete')) {
+          clearInterval(interval);
+          clearTimeout(timer);
+          resolve();
+        }
+      }, 50);
+      const timer = setTimeout(() => {
+        clearInterval(interval);
+        resolve();
+      }, timeoutMs);
+    });
+    closer.close();
+
+    return {
+      finalCount: count,
+      firstAgentDeltaMs,
+      milestones,
+      timedOut: !milestones.some((m) => m.event === 'complete'),
+    };
+  });
+
+  return c.json({ ...result.body, elapsedMs: result.elapsedMs });
+});
+
+app.post('/protocol-config', async (c) => {
+  let payload: { rpcUrl?: string; network?: ProtocolCluster };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  const network = payload.network ?? NETWORK_ENV;
+  const callRpc = payload.rpcUrl ? createSolanaRpc(payload.rpcUrl) : rpc;
+
+  const result = await instrument('protocol-config', async () => {
+    const programId = getProtocolProgramId(network);
+    const config = await getProtocolConfig(callRpc, programId);
+    return { config };
+  });
+  return c.json({ ...result.body, elapsedMs: result.elapsedMs });
+});
+
+app.get('/pool/info', (c) =>
+  c.json({
+    identitySize: identityPool.size(),
+    relays: RELAY_LIST,
+    rpcUrl: RPC_URL,
+    network: NETWORK_ENV,
+  }),
+);
+
+// ---- Fleet routes (Phase 4: Q1 - agent fleet scale) ----
+//
+// The fleet simulator publishes synthetic NIP-89 announcements so discovery
+// scenarios can sweep "how does fetchAgents latency grow with N online agents".
+// The fleet is a single shared resource per bridge process - one scenario at
+// a time.
+app.post('/fleet/resize', async (c) => {
+  let payload: {
+    size?: number;
+    capability?: string;
+    pingIntervalMs?: number;
+    republishMs?: number;
+  };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  const size = Number(payload.size ?? 0);
+  if (!Number.isInteger(size) || size < 0) {
+    return c.json({ error: 'size must be a non-negative integer' }, 400);
+  }
+  if (!fleet) {
+    fleet = new FleetSimulator({
+      capability: payload.capability ?? 'translate',
+      relays: RELAY_LIST,
+      pingIntervalMs: payload.pingIntervalMs ?? 30_000,
+      republishMs: payload.republishMs ?? 120_000,
+    });
+  }
+  const fleetRef = fleet;
+  const result = await instrument('fleet-resize', async () => {
+    const snap = await fleetRef.resize(size);
+    return snap;
+  });
+  return c.json({ ...result.body, elapsedMs: result.elapsedMs });
+});
+
+app.post('/fleet/stop', (c) => {
+  if (!fleet) {
+    return c.json({ size: 0, stopped: true });
+  }
+  const snap = fleet.stop();
+  fleet = null;
+  return c.json({ ...snap, stopped: true });
+});
+
+app.get('/fleet/info', (c) => c.json(fleet ? fleet.snapshot() : { size: 0 }));
+
+// ---- MCP routes (Phase 6: Q3 - MCP discovery latency) ----
+//
+// One MCP child process per bridge instance. The driver mirrors how a real
+// assistant client (Claude Desktop, Cursor, Windsurf) consumes elisym-mcp:
+// long-lived stdio connection + sequential JSON-RPC tool calls.
+app.post('/mcp/start', async (c) => {
+  let payload: { agent?: string; command?: string; env?: Record<string, string> };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  const agent = payload.agent ?? process.env.MCP_AGENT;
+  if (!agent) {
+    return c.json({ error: 'agent is required (in body or MCP_AGENT env)' }, 400);
+  }
+  if (mcp.isRunning()) {
+    return c.json({ alreadyRunning: true, uptimeMs: mcp.uptimeMs() });
+  }
+  try {
+    await mcp.start({ agent, command: payload.command, env: payload.env });
+    return c.json({ started: true });
+  } catch (err) {
+    return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
+  }
+});
+
+app.post('/mcp/call', async (c) => {
+  let payload: { tool?: string; args?: Record<string, unknown> };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  if (!payload.tool) {
+    return c.json({ error: 'tool is required' }, 400);
+  }
+  if (!mcp.isRunning()) {
+    return c.json({ error: 'mcp not started; POST /mcp/start first' }, 400);
+  }
+  const tool = payload.tool;
+  const args = payload.args ?? {};
+  const wrapped = await instrument('mcp-call', async () => mcp.callTool(tool, args));
+  return c.json({ ...wrapped.body, bridgeElapsedMs: wrapped.elapsedMs });
+});
+
+app.post('/mcp/stop', async (c) => {
+  await mcp.stop();
+  return c.json({ stopped: true });
+});
+
+app.get('/mcp/info', (c) =>
+  c.json({
+    running: mcp.isRunning(),
+    uptimeMs: mcp.uptimeMs(),
+    totalCalls: mcp.totalCalls(),
+  }),
+);
+
+// ---- /job/submit (Phase 7: Q4 - provider saturation) ----
+//
+// Publishes a broadcast (un-targeted) job-request event so any provider
+// listening for the capability picks it up. Uses a customer identity from
+// the round-robin pool so the per-customer rate limiter on the provider
+// (20 jobs / 10 min) does not trip until the pool itself wraps around.
+app.post('/job/submit', async (c) => {
+  let payload: { capability?: string; input?: string; providerPubkey?: string };
+  try {
+    payload = await c.req.json();
+  } catch {
+    payload = {};
+  }
+  const capability = payload.capability ?? 'translate';
+  const input = payload.input ?? `perf job ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const wrapped = await instrument('job-submit', async () => {
+    const entry = identityPool.next();
+    const jobEventId = await client.marketplace.submitJobRequest(entry.identity, {
+      input,
+      capability,
+      providerPubkey: payload.providerPubkey,
+    });
+    return { jobEventId, customerPubkey: entry.pubkeyHex };
+  });
+  return c.json({ ...wrapped.body, elapsedMs: wrapped.elapsedMs });
+});
+
+// Bun-native server. Bridge runs only under bun (the monorepo's runtime),
+// so we avoid pulling in @hono/node-server.
+const server = Bun.serve({ fetch: app.fetch, port: PORT, hostname: HOST });
+process.stdout.write(`bridge: http://${server.hostname}:${server.port}\n`);
+process.stdout.write(`  relays: ${RELAY_LIST.join(', ')}\n`);
+process.stdout.write(`  rpc:    ${RPC_URL}\n`);
+process.stdout.write(`  pool:   ${identityPool.size()} identities\n`);
+
+const shutdown = (signal: string) => {
+  process.stderr.write(`\nbridge: ${signal} received, closing\n`);
+  server.stop();
+  setTimeout(() => process.exit(0), 100).unref();
+};
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/packages/perf/docker/docker-compose.yml
+++ b/packages/perf/docker/docker-compose.yml
@@ -1,0 +1,61 @@
+# Local-only perf stack. Pinned image versions to keep numbers comparable run-to-run.
+# Phase 1 brings up: strfry + prometheus + grafana.
+# Later phases add: solana-test-validator, anchor-deploy (one-shot), bridge, provider.
+name: elisym-perf
+
+services:
+  strfry:
+    image: dockurr/strfry:latest
+    container_name: elisym-perf-strfry
+    ports:
+      - '7777:7777'
+    volumes:
+      - ./strfry.conf:/etc/strfry.conf:ro
+      - strfry-data:/var/lib/strfry
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:7777/']
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    container_name: elisym-perf-prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=2d'
+      - '--web.enable-remote-write-receiver'
+      - '--enable-feature=native-histograms'
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: elisym-perf-grafana
+    ports:
+      - '3000:3000'
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_AUTH_ANONYMOUS_ORG_ROLE: 'Viewer'
+      GF_AUTH_DISABLE_LOGIN_FORM: 'false'
+      GF_SECURITY_ADMIN_USER: 'admin'
+      GF_SECURITY_ADMIN_PASSWORD: 'admin'
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+volumes:
+  strfry-data:
+  prometheus-data:
+  grafana-data:

--- a/packages/perf/docker/docker-compose.yml
+++ b/packages/perf/docker/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       - strfry-data:/var/lib/strfry
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'wget', '-qO-', 'http://localhost:7777/']
+      # strfry speaks pure WebSocket on 7777 - HTTP probes get refused. A bare
+      # TCP-port check is enough to know the listener is up.
+      test: ['CMD', 'nc', '-z', '127.0.0.1', '7777']
       interval: 5s
       timeout: 3s
       retries: 10

--- a/packages/perf/docker/grafana/dashboards/e2e.json
+++ b/packages/perf/docker/grafana/dashboards/e2e.json
@@ -1,0 +1,139 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(elisym_jobs_received_total[1m]))",
+          "legendFormat": "provider receives/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(elisym_jobs_completed_total{result=\"ok\"}[1m]))",
+          "legendFormat": "provider completes/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(elisym_bridge_calls_total{route=\"discover\"}[1m]))",
+          "legendFormat": "bridge discover/s",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(elisym_bridge_calls_total{route=\"job-submit\"}[1m]))",
+          "legendFormat": "bridge job-submit/s",
+          "refId": "D"
+        }
+      ],
+      "title": "End-to-end throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_discovery_call_ms{quantile=\"0.95\"}",
+          "legendFormat": "discovery p95",
+          "refId": "A"
+        },
+        {
+          "expr": "k6_job_submit_call_ms{quantile=\"0.95\"}",
+          "legendFormat": "job-submit p95",
+          "refId": "B"
+        }
+      ],
+      "title": "User-side latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        { "expr": "elisym_jobs_in_flight", "legendFormat": "in flight", "refId": "A" },
+        { "expr": "elisym_jobs_pending", "legendFormat": "pending", "refId": "B" }
+      ],
+      "title": "Provider queue",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(elisym_job_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "job duration p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Provider job duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "percentunit" }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 5,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_discovery_success_rate",
+          "legendFormat": "discovery success rate",
+          "refId": "A"
+        },
+        {
+          "expr": "k6_job_submit_success_rate",
+          "legendFormat": "job-submit success rate",
+          "refId": "B"
+        }
+      ],
+      "title": "Success rates (drift = leak / regression)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["elisym", "e2e"],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "elisym - end-to-end steady state",
+  "uid": "elisym-perf-e2e",
+  "version": 1,
+  "weekStart": ""
+}

--- a/packages/perf/docker/grafana/dashboards/e2e.json
+++ b/packages/perf/docker/grafana/dashboards/e2e.json
@@ -50,12 +50,12 @@
       },
       "targets": [
         {
-          "expr": "k6_discovery_call_ms{quantile=\"0.95\"}",
+          "expr": "k6_discovery_call_ms_p95",
           "legendFormat": "discovery p95",
           "refId": "A"
         },
         {
-          "expr": "k6_job_submit_call_ms{quantile=\"0.95\"}",
+          "expr": "k6_job_submit_call_ms_p95",
           "legendFormat": "job-submit p95",
           "refId": "B"
         }

--- a/packages/perf/docker/grafana/dashboards/k6.json
+++ b/packages/perf/docker/grafana/dashboards/k6.json
@@ -1,0 +1,146 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" } },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        { "expr": "sum(k6_vus)", "legendFormat": "active VUs", "refId": "A" },
+        { "expr": "sum(k6_vus_max)", "legendFormat": "max VUs", "refId": "B" }
+      ],
+      "title": "Virtual users",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" } },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(k6_http_reqs_total[30s]))",
+          "legendFormat": "http req/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(k6_iterations_total[30s]))",
+          "legendFormat": "iterations/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 7 },
+      "id": 3,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_http_req_duration{quantile=\"0.5\"}",
+          "legendFormat": "p50 {{scenario}}",
+          "refId": "A"
+        },
+        {
+          "expr": "k6_http_req_duration{quantile=\"0.95\"}",
+          "legendFormat": "p95 {{scenario}}",
+          "refId": "B"
+        },
+        {
+          "expr": "k6_http_req_duration{quantile=\"0.99\"}",
+          "legendFormat": "p99 {{scenario}}",
+          "refId": "C"
+        }
+      ],
+      "title": "HTTP request duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 16 },
+      "id": 4,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_ws_connecting{quantile=\"0.95\"}",
+          "legendFormat": "ws connect p95",
+          "refId": "A"
+        },
+        {
+          "expr": "k6_ws_session_duration{quantile=\"0.95\"}",
+          "legendFormat": "ws session p95",
+          "refId": "B"
+        }
+      ],
+      "title": "WebSocket latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "percentunit" }
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 16 },
+      "id": 5,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(k6_http_req_failed_total[30s])) / clamp_min(sum(rate(k6_http_reqs_total[30s])), 1)",
+          "legendFormat": "http error rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Error rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["elisym", "k6"],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "k6 overview",
+  "uid": "elisym-perf-k6-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/packages/perf/docker/grafana/dashboards/k6.json
+++ b/packages/perf/docker/grafana/dashboards/k6.json
@@ -68,17 +68,17 @@
       },
       "targets": [
         {
-          "expr": "k6_http_req_duration{quantile=\"0.5\"}",
+          "expr": "k6_http_req_duration_p50",
           "legendFormat": "p50 {{scenario}}",
           "refId": "A"
         },
         {
-          "expr": "k6_http_req_duration{quantile=\"0.95\"}",
+          "expr": "k6_http_req_duration_p95",
           "legendFormat": "p95 {{scenario}}",
           "refId": "B"
         },
         {
-          "expr": "k6_http_req_duration{quantile=\"0.99\"}",
+          "expr": "k6_http_req_duration_p99",
           "legendFormat": "p99 {{scenario}}",
           "refId": "C"
         }
@@ -97,12 +97,12 @@
       },
       "targets": [
         {
-          "expr": "k6_ws_connecting{quantile=\"0.95\"}",
+          "expr": "k6_ws_connecting_p95",
           "legendFormat": "ws connect p95",
           "refId": "A"
         },
         {
-          "expr": "k6_ws_session_duration{quantile=\"0.95\"}",
+          "expr": "k6_ws_session_duration_p95",
           "legendFormat": "ws session p95",
           "refId": "B"
         }

--- a/packages/perf/docker/grafana/dashboards/provider.json
+++ b/packages/perf/docker/grafana/dashboards/provider.json
@@ -1,0 +1,142 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        { "expr": "elisym_jobs_in_flight", "legendFormat": "in flight", "refId": "A" },
+        { "expr": "elisym_jobs_pending", "legendFormat": "pending past p-limit", "refId": "B" }
+      ],
+      "title": "Provider queue depth (Q4)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(elisym_jobs_received_total[30s]))",
+          "legendFormat": "received/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(elisym_jobs_completed_total{result=\"ok\"}[30s]))",
+          "legendFormat": "completed ok/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(elisym_jobs_completed_total{result=\"error\"}[30s]))",
+          "legendFormat": "completed error/s",
+          "refId": "C"
+        }
+      ],
+      "title": "Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" } },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+      "id": 3,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(elisym_job_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(elisym_job_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(elisym_job_duration_seconds_bucket[1m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Job duration (provider-side)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 18 },
+      "id": 4,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "elisym_health_gate_state{status=\"healthy\"}",
+          "legendFormat": "healthy {{provider}}/{{model}}",
+          "refId": "A"
+        },
+        {
+          "expr": "elisym_health_gate_state{status=\"billing\"}",
+          "legendFormat": "billing {{provider}}/{{model}}",
+          "refId": "B"
+        },
+        {
+          "expr": "elisym_health_gate_state{status=\"invalid\"}",
+          "legendFormat": "invalid {{provider}}/{{model}}",
+          "refId": "C"
+        }
+      ],
+      "title": "LLM health gate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 18 },
+      "id": 5,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(k6_submit_call_ms_count[30s]))",
+          "legendFormat": "k6 submit/s (load injector)",
+          "refId": "A"
+        }
+      ],
+      "title": "Load injector rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["elisym", "provider"],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "elisym - provider saturation",
+  "uid": "elisym-perf-provider",
+  "version": 1,
+  "weekStart": ""
+}

--- a/packages/perf/docker/grafana/dashboards/relay.json
+++ b/packages/perf/docker/grafana/dashboards/relay.json
@@ -28,17 +28,17 @@
       },
       "targets": [
         {
-          "expr": "k6_discover_call_ms{quantile=\"0.5\"}",
+          "expr": "k6_discover_call_ms_p50",
           "legendFormat": "p50 fleet={{fleet_size}}",
           "refId": "A"
         },
         {
-          "expr": "k6_discover_call_ms{quantile=\"0.95\"}",
+          "expr": "k6_discover_call_ms_p95",
           "legendFormat": "p95 fleet={{fleet_size}}",
           "refId": "B"
         },
         {
-          "expr": "k6_discover_call_ms{quantile=\"0.99\"}",
+          "expr": "k6_discover_call_ms_p99",
           "legendFormat": "p99 fleet={{fleet_size}}",
           "refId": "C"
         }
@@ -57,7 +57,7 @@
       },
       "targets": [
         {
-          "expr": "k6_discover_bridge_elapsed_ms{quantile=\"0.95\"}",
+          "expr": "k6_discover_bridge_elapsed_ms_p95",
           "legendFormat": "bridge p95 fleet={{fleet_size}}",
           "refId": "A"
         }
@@ -76,7 +76,7 @@
       },
       "targets": [
         {
-          "expr": "k6_discover_agents_returned{quantile=\"0.5\"}",
+          "expr": "k6_discover_agents_returned_p50",
           "legendFormat": "median agents returned fleet={{fleet_size}}",
           "refId": "A"
         }

--- a/packages/perf/docker/grafana/dashboards/relay.json
+++ b/packages/perf/docker/grafana/dashboards/relay.json
@@ -1,0 +1,123 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_discover_call_ms{quantile=\"0.5\"}",
+          "legendFormat": "p50 fleet={{fleet_size}}",
+          "refId": "A"
+        },
+        {
+          "expr": "k6_discover_call_ms{quantile=\"0.95\"}",
+          "legendFormat": "p95 fleet={{fleet_size}}",
+          "refId": "B"
+        },
+        {
+          "expr": "k6_discover_call_ms{quantile=\"0.99\"}",
+          "legendFormat": "p99 fleet={{fleet_size}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Discovery latency by fleet size (Q1)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "id": 2,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_discover_bridge_elapsed_ms{quantile=\"0.95\"}",
+          "legendFormat": "bridge p95 fleet={{fleet_size}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bridge elapsed (sanity vs k6 wall-clock)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "id": 3,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "k6_discover_agents_returned{quantile=\"0.5\"}",
+          "legendFormat": "median agents returned fleet={{fleet_size}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Agents returned per call",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+      "id": 4,
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(elisym_bridge_calls_total{route=\"discover\"}[30s])) by (outcome)",
+          "legendFormat": "discover {{outcome}}/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(elisym_bridge_calls_total{route=\"fleet-resize\"}[30s])) by (outcome)",
+          "legendFormat": "fleet-resize {{outcome}}/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Bridge call rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["elisym", "relay", "discovery"],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "elisym - relay & discovery",
+  "uid": "elisym-perf-relay",
+  "version": 1,
+  "weekStart": ""
+}

--- a/packages/perf/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/packages/perf/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: elisym-perf
+    orgId: 1
+    folder: elisym-perf
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/packages/perf/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/packages/perf/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: 5s
+      httpMethod: POST

--- a/packages/perf/docker/prometheus.yml
+++ b/packages/perf/docker/prometheus.yml
@@ -1,0 +1,27 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+  external_labels:
+    stack: elisym-perf
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: provider
+    static_configs:
+      - targets: ['host.docker.internal:9464']
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: provider
+
+  - job_name: bridge
+    static_configs:
+      - targets: ['host.docker.internal:3030']
+    metrics_path: /metrics
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: bridge

--- a/packages/perf/docker/strfry.conf
+++ b/packages/perf/docker/strfry.conf
@@ -1,0 +1,72 @@
+##
+## strfry config for local perf testing.
+## Tuned for high connection counts and large fanout. Not safe for public deployment.
+##
+
+db = "/var/lib/strfry"
+
+dbParams {
+    maxreaders = 256
+    mapsize = 10737418240   # 10 GiB; ample headroom for perf runs
+    noReadAhead = false
+}
+
+events {
+    maxEventSize = 65536
+    rejectEventsNewerThanSeconds = 900
+    rejectEventsOlderThanSeconds = 94608000
+    rejectEphemeralEventsOlderThanSeconds = 60
+    ephemeralEventsLifetimeSeconds = 300
+    maxNumTags = 250
+    maxTagValSize = 1024
+}
+
+relay {
+    bind = "0.0.0.0"
+    port = 7777
+    nofiles = 1000000
+    realIpHeader = ""
+
+    info {
+        name = "elisym-perf-local"
+        description = "Local-only strfry for perf testing. Do not connect from the public internet."
+        pubkey = ""
+        contact = ""
+    }
+
+    maxWebsocketPayloadSize = 131072
+    autoPingSeconds = 55
+    enableTcpKeepalive = true
+    queryTimesliceBudgetMicroseconds = 10000
+    maxFilterLimit = 5000
+    maxSubsPerConnection = 100
+
+    writePolicy {
+        plugin = ""
+    }
+
+    compression {
+        enabled = true
+        slidingWindow = true
+    }
+
+    logging {
+        dumpInAll = false
+        dumpInEvents = false
+        dumpInReqs = false
+        dbScanPerf = false
+        invalidEvents = true
+    }
+
+    numThreads {
+        ingester = 4
+        reqWorker = 4
+        reqMonitor = 4
+        negentropy = 2
+    }
+
+    negentropy {
+        enabled = true
+        maxSyncEvents = 1000000
+    }
+}

--- a/packages/perf/k6/lib/env.js
+++ b/packages/perf/k6/lib/env.js
@@ -1,0 +1,37 @@
+// Shared env-var helpers. All k6 scenarios pull URLs and tunables through these
+// so a single command-line override (`-e KEY=value`) is enough to retarget a run.
+
+export const STRFRY_WS = __ENV.STRFRY_WS || 'ws://localhost:7777';
+export const STRFRY_HTTP = __ENV.STRFRY_HTTP || 'http://localhost:7777';
+export const RPC_URL = __ENV.RPC_URL || 'http://localhost:8899';
+export const BRIDGE_URL = __ENV.BRIDGE_URL || 'http://localhost:3030';
+export const PROVIDER_METRICS_URL = __ENV.PROVIDER_METRICS_URL || 'http://localhost:9464/metrics';
+
+export const SCENARIO = __ENV.SCENARIO || 'unnamed';
+export const RUN_ID = __ENV.RUN_ID || `${SCENARIO}-${Date.now()}`;
+
+export function intEnv(name, fallback) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`env ${name}=${raw} is not a valid integer`);
+  }
+  return parsed;
+}
+
+export function floatEnv(name, fallback) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`env ${name}=${raw} is not a valid float`);
+  }
+  return parsed;
+}
+
+export function boolEnv(name, fallback) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') return fallback;
+  return raw === '1' || raw.toLowerCase() === 'true';
+}

--- a/packages/perf/k6/lib/nostr.js
+++ b/packages/perf/k6/lib/nostr.js
@@ -1,0 +1,163 @@
+// Minimal NIP-01 helpers for k6 ws scenarios.
+//
+// We deliberately use a fake-but-well-formed signature scheme: each event id is
+// a sha256 hash over the canonical payload, but the signature itself is zeroed
+// out. strfry will reject these UNLESS it is run in a permissive mode for tests,
+// or unless we sign for real. For phase 1 we sign for real with @noble/secp256k1
+// inlined, because k6 cannot import npm packages directly.
+//
+// k6 ships with `k6/crypto` (sha256, hmac) and `k6/encoding` (hex, base64).
+// We depend on those for hashing and on a small bundled secp256k1 helper that
+// scenarios can opt into via `signEvent`. For now we rely on a SCHNORR_SIG_HEX
+// env var to allow short-circuiting signature work when only throughput matters
+// and the relay is configured to skip signature verification.
+
+import { check } from 'k6';
+import { sha256 } from 'k6/crypto';
+
+const ZERO_SIG = '0'.repeat(128);
+
+/**
+ * Build a canonical NIP-01 event-id payload string and return its sha256 hex.
+ * Per NIP-01: id = sha256(json([0, pubkey, created_at, kind, tags, content])).
+ */
+export function computeEventId(event) {
+  const payload = JSON.stringify([
+    0,
+    event.pubkey,
+    event.created_at,
+    event.kind,
+    event.tags,
+    event.content,
+  ]);
+  return sha256(payload, 'hex');
+}
+
+/**
+ * Build a NIP-01 event with a zero signature. Useful when:
+ *   - the relay is in a permissive test mode that does not verify sigs, OR
+ *   - the scenario only measures relay accept/reject throughput, not validity.
+ *
+ * For phase 1 with stock strfry, this will be REJECTED. The scenario records
+ * both ACCEPTED (true) and REJECTED-with-bad-sig (false) outcomes; the goal
+ * is to measure the round-trip latency of the OK message either way.
+ */
+export function makeUnsignedEvent({
+  pubkey,
+  kind,
+  content = '',
+  tags = [],
+  createdAt = nowSecs(),
+}) {
+  const event = {
+    pubkey,
+    kind,
+    content,
+    tags,
+    created_at: createdAt,
+    sig: ZERO_SIG,
+  };
+  event.id = computeEventId(event);
+  return event;
+}
+
+export function nowSecs() {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Send an EVENT to the relay over an open ws and resolve with the OK frame.
+ *
+ * Returns a promise-like by using `socket.setTimeout` semantics: we install a
+ * one-shot OK handler that records the outcome into the supplied trend metric
+ * and calls onResolve(eventId, accepted, message).
+ *
+ * Caller is responsible for closing the socket after their iteration ends.
+ */
+export function publishEvent(
+  socket,
+  event,
+  { okTrend, sentCounter, ackCounter, errorCounter, onResolve },
+) {
+  const start = Date.now();
+  const sent = JSON.stringify(['EVENT', event]);
+  socket.send(sent);
+  if (sentCounter) sentCounter.add(1);
+
+  // k6's k6/ws Socket has no clearTimeout, so the 5s deadline always fires.
+  // Use a per-event flag so a late timeout can't double-count an OK that
+  // already arrived (would otherwise inflate errors and skew accept rate).
+  let resolved = false;
+
+  socket.setTimeout(() => {
+    if (resolved) return;
+    resolved = true;
+    if (errorCounter) errorCounter.add(1);
+    onResolve?.(event.id, false, 'timeout');
+  }, 5000);
+
+  socket.on('message', (raw) => {
+    if (resolved) return;
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (_err) {
+      return;
+    }
+    if (!Array.isArray(parsed) || parsed[0] !== 'OK' || parsed[1] !== event.id) return;
+    resolved = true;
+    const accepted = parsed[2] === true;
+    const elapsed = Date.now() - start;
+    if (okTrend) okTrend.add(elapsed);
+    if (accepted && ackCounter) ackCounter.add(1);
+    if (!accepted && errorCounter) errorCounter.add(1);
+    onResolve?.(event.id, accepted, parsed[3] ?? '');
+  });
+}
+
+/**
+ * Send a REQ subscription and resolve when EOSE arrives.
+ * `onEvent(event)` is invoked for every EVENT frame matching the subscription.
+ * Returns the subscription id; caller is responsible for sending CLOSE.
+ */
+export function subscribe(socket, subId, filter, { onEvent, onEose, eoseTrend }) {
+  const start = Date.now();
+  const req = JSON.stringify(['REQ', subId, filter]);
+  socket.send(req);
+
+  socket.on('message', (raw) => {
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (_err) {
+      return;
+    }
+    if (!Array.isArray(parsed) || parsed[1] !== subId) return;
+    const frame = parsed[0];
+    if (frame === 'EVENT') {
+      onEvent?.(parsed[2]);
+      return;
+    }
+    if (frame === 'EOSE') {
+      const elapsed = Date.now() - start;
+      if (eoseTrend) eoseTrend.add(elapsed);
+      onEose?.(elapsed);
+      return;
+    }
+  });
+
+  return subId;
+}
+
+export function closeSubscription(socket, subId) {
+  socket.send(JSON.stringify(['CLOSE', subId]));
+}
+
+/**
+ * Sanity-check helper for scenario teardown: ensure we got at least one OK.
+ */
+export function expectAtLeastOneAck(ackCounter) {
+  check(null, {
+    'relay produced at least one OK ack': () => ackCounter && ackCounter.count > 0,
+  });
+}

--- a/packages/perf/k6/lib/nostr.js
+++ b/packages/perf/k6/lib/nostr.js
@@ -66,53 +66,58 @@ export function nowSecs() {
 }
 
 /**
- * Send an EVENT to the relay over an open ws and resolve with the OK frame.
+ * Install a single OK-frame router on a ws Socket and return a `publish(event)`
+ * binder. All pending sends share one `socket.on('message', ...)` handler — this
+ * matters for high-throughput scenarios where registering a fresh listener per
+ * event accumulates handlers and (worse) can race with k6's message dispatch.
  *
- * Returns a promise-like by using `socket.setTimeout` semantics: we install a
- * one-shot OK handler that records the outcome into the supplied trend metric
- * and calls onResolve(eventId, accepted, message).
- *
- * Caller is responsible for closing the socket after their iteration ends.
+ * Caller drives sending via `socket.setInterval` / `setTimeout` (non-blocking);
+ * the router resolves each event when its matching OK frame arrives. Pending
+ * sends still outstanding when the socket closes can be reaped via `flush()`.
  */
-export function publishEvent(
+export function createOkRouter(
   socket,
-  event,
   { okTrend, sentCounter, ackCounter, errorCounter, onResolve },
 ) {
-  const start = Date.now();
-  const sent = JSON.stringify(['EVENT', event]);
-  socket.send(sent);
-  if (sentCounter) sentCounter.add(1);
-
-  // k6's k6/ws Socket has no clearTimeout, so the 5s deadline always fires.
-  // Use a per-event flag so a late timeout can't double-count an OK that
-  // already arrived (would otherwise inflate errors and skew accept rate).
-  let resolved = false;
-
-  socket.setTimeout(() => {
-    if (resolved) return;
-    resolved = true;
-    if (errorCounter) errorCounter.add(1);
-    onResolve?.(event.id, false, 'timeout');
-  }, 5000);
+  const pending = new Map(); // id -> startMs
 
   socket.on('message', (raw) => {
-    if (resolved) return;
     let parsed;
     try {
       parsed = JSON.parse(raw);
     } catch (_err) {
       return;
     }
-    if (!Array.isArray(parsed) || parsed[0] !== 'OK' || parsed[1] !== event.id) return;
-    resolved = true;
+    if (!Array.isArray(parsed) || parsed[0] !== 'OK') return;
+    const id = parsed[1];
+    const start = pending.get(id);
+    if (start === undefined) return;
+    pending.delete(id);
     const accepted = parsed[2] === true;
     const elapsed = Date.now() - start;
     if (okTrend) okTrend.add(elapsed);
     if (accepted && ackCounter) ackCounter.add(1);
     if (!accepted && errorCounter) errorCounter.add(1);
-    onResolve?.(event.id, accepted, parsed[3] ?? '');
+    onResolve?.(id, accepted, parsed[3] ?? '');
   });
+
+  function publish(event) {
+    pending.set(event.id, Date.now());
+    if (sentCounter) sentCounter.add(1);
+    socket.send(JSON.stringify(['EVENT', event]));
+  }
+
+  function flush(reason = 'closed') {
+    for (const id of pending.keys()) {
+      if (errorCounter) errorCounter.add(1);
+      onResolve?.(id, false, reason);
+    }
+    const count = pending.size;
+    pending.clear();
+    return count;
+  }
+
+  return { publish, flush, pendingCount: () => pending.size };
 }
 
 /**

--- a/packages/perf/k6/lib/solana-rpc.js
+++ b/packages/perf/k6/lib/solana-rpc.js
@@ -1,0 +1,66 @@
+// Minimal JSON-RPC helpers for k6 scenarios that hit Solana RPC directly.
+// Centralised so scenarios share one error-classification policy and one URL.
+
+import { check } from 'k6';
+import http from 'k6/http';
+import { RPC_URL } from './env.js';
+
+let requestId = 0;
+
+function nextId() {
+  requestId = (requestId + 1) % Number.MAX_SAFE_INTEGER;
+  return requestId;
+}
+
+/**
+ * Issue a JSON-RPC request and return { result, error, status, durationMs }.
+ * Does NOT throw on RPC errors; scenarios decide how to count them.
+ */
+export function rpcCall(method, params = [], { url = RPC_URL, tags = {} } = {}) {
+  const start = Date.now();
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: nextId(),
+    method,
+    params,
+  });
+  const res = http.post(url, body, {
+    headers: { 'Content-Type': 'application/json' },
+    tags: { rpc_method: method, ...tags },
+  });
+  const durationMs = Date.now() - start;
+
+  let parsed = null;
+  try {
+    parsed = res.json();
+  } catch (_err) {
+    parsed = null;
+  }
+  return {
+    status: res.status,
+    durationMs,
+    result: parsed?.result,
+    error: parsed?.error,
+  };
+}
+
+/** Returns the value (number) of getSlot, or null on error. */
+export function getSlot(opts) {
+  const r = rpcCall('getSlot', [], opts);
+  return r.error ? null : r.result;
+}
+
+/** Returns getBalance value (lamports as number), or null on error. */
+export function getBalance(address, opts) {
+  const r = rpcCall('getBalance', [address], opts);
+  return r.error ? null : (r.result?.value ?? null);
+}
+
+/** Sanity check, used in scenario setup(). */
+export function pingRpc(url = RPC_URL) {
+  const r = rpcCall('getHealth', [], { url });
+  check(r, {
+    [`rpc ${url} responds`]: () => r.status === 200 && !r.error,
+  });
+  return r.status === 200 && !r.error;
+}

--- a/packages/perf/k6/lib/stats.js
+++ b/packages/perf/k6/lib/stats.js
@@ -1,0 +1,68 @@
+// Helpers for writing run summaries to disk.
+//
+// k6 calls `handleSummary(data)` at end-of-test if the scenario exports it.
+// We forward the raw JSON (so external tooling can crunch percentiles) plus a
+// human-readable HTML rendering via the official `k6-summary` template.
+
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.1.0/index.js';
+import { RUN_ID, SCENARIO } from './env.js';
+
+// Honour the runner's REPORTS_DIR env so summary files land in the host's
+// packages/perf/k6/reports/ when k6 is invoked from scripts/run.sh.
+// Falls back to a relative path so a bare `k6 run` still produces output.
+const REPORTS_DIR = __ENV.REPORTS_DIR || './k6/reports';
+
+export function writeSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    [`${REPORTS_DIR}/${SCENARIO}-${RUN_ID}.json`]: JSON.stringify(data, null, 2),
+    [`${REPORTS_DIR}/${SCENARIO}-${RUN_ID}.html`]: renderHtml(data),
+  };
+}
+
+function renderHtml(data) {
+  const metrics = Object.entries(data.metrics ?? {})
+    .map(([name, m]) => {
+      const values = Object.entries(m.values ?? {})
+        .map(([k, v]) => `<dt>${escape(k)}</dt><dd>${formatValue(v)}</dd>`)
+        .join('');
+      return `<section><h2>${escape(name)} <small>(${escape(m.type)})</small></h2><dl>${values}</dl></section>`;
+    })
+    .join('');
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>k6 ${escape(SCENARIO)} ${escape(RUN_ID)}</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;margin:24px;background:#0b0d10;color:#e6e6e6;}
+h1{font-size:18px;border-bottom:1px solid #333;padding-bottom:8px;}
+h2{font-size:14px;margin-top:24px;}
+dl{display:grid;grid-template-columns:auto 1fr;gap:4px 16px;font-size:13px;}
+dt{color:#9ca3af;}
+small{color:#9ca3af;font-weight:normal;}
+section{padding:8px 12px;background:#11151a;border-radius:6px;margin-bottom:12px;}
+</style></head>
+<body>
+<h1>k6 - ${escape(SCENARIO)} - ${escape(RUN_ID)}</h1>
+${metrics}
+</body></html>`;
+}
+
+function formatValue(v) {
+  if (typeof v === 'number') {
+    return Number.isInteger(v) ? String(v) : v.toFixed(3);
+  }
+  return escape(String(v));
+}
+
+function escape(s) {
+  return String(s).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[c],
+  );
+}

--- a/packages/perf/k6/scenarios/agent_fleet_scale.js
+++ b/packages/perf/k6/scenarios/agent_fleet_scale.js
@@ -1,0 +1,124 @@
+// agent_fleet_scale.js
+//
+// Q1: how many agents can stay online before discovery degrades?
+//
+// Methodology:
+//   - For each fleet size in FLEET_SIZES (default 0,10,100,500,1000,2500,5000):
+//       1. POST /fleet/resize { size }    -> bridge spins synthetic agents.
+//       2. Sleep PROPAGATION_S            -> let relay index events.
+//       3. Run SAMPLES discovery calls    -> measure latency.
+//   - Latency, agents-returned, errors are tagged with `fleet_size` so
+//     Grafana can plot a single chart "p50/p95/p99 vs N agents".
+//
+// Single VU, sequential by design - we want a clean step function, not
+// concurrency noise. To stress concurrency at fixed fleet size, see
+// `web_discovery_latency.js` (Phase 5).
+
+import { check, sleep } from 'k6';
+import http from 'k6/http';
+import { Trend, Counter, Rate } from 'k6/metrics';
+import { BRIDGE_URL, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const SAMPLES = intEnv('SAMPLES', 10);
+const PROPAGATION_S = intEnv('PROPAGATION_S', 5);
+const AGENT_LIMIT = intEnv('AGENT_LIMIT', 200);
+const NETWORK = __ENV.NETWORK || 'devnet';
+const CAPABILITY = __ENV.CAPABILITY || 'translate';
+const FLEET_SIZES = (__ENV.FLEET_SIZES || '0,10,100,500,1000,2500,5000')
+  .split(',')
+  .map((s) => Number.parseInt(s.trim(), 10))
+  .filter((n) => Number.isInteger(n) && n >= 0);
+
+const discoverLatency = new Trend('discover_call_ms', true);
+const bridgeElapsed = new Trend('discover_bridge_elapsed_ms', true);
+const agentsReturned = new Trend('discover_agents_returned');
+const errors = new Counter('discover_errors_total');
+const successRate = new Rate('discover_success_rate');
+
+export const options = {
+  scenarios: {
+    sweep: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '30m',
+    },
+  },
+  // Thresholds intentionally lenient - this scenario maps the curve, it
+  // does not gate on a single number.
+  thresholds: {
+    discover_success_rate: ['rate>0.9'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+function resizeFleet(size) {
+  const res = http.post(
+    `${BRIDGE_URL}/fleet/resize`,
+    JSON.stringify({ size, capability: CAPABILITY }),
+    { headers: { 'Content-Type': 'application/json' }, timeout: '120s' },
+  );
+  check(res, { 'fleet resize 200': (r) => r.status === 200 });
+  return res;
+}
+
+function discoverOnce(fleetSize) {
+  const start = Date.now();
+  const res = http.post(
+    `${BRIDGE_URL}/discover`,
+    JSON.stringify({ network: NETWORK, limit: AGENT_LIMIT }),
+    { headers: { 'Content-Type': 'application/json' }, timeout: '30s' },
+  );
+  const elapsed = Date.now() - start;
+  const ok = res.status === 200;
+  successRate.add(ok, { fleet_size: String(fleetSize) });
+  discoverLatency.add(elapsed, { fleet_size: String(fleetSize) });
+  if (!ok) {
+    errors.add(1, { fleet_size: String(fleetSize) });
+    return;
+  }
+  let body;
+  try {
+    body = res.json();
+  } catch (_err) {
+    errors.add(1, { fleet_size: String(fleetSize) });
+    return;
+  }
+  if (typeof body?.elapsedMs === 'number') {
+    bridgeElapsed.add(body.elapsedMs, { fleet_size: String(fleetSize) });
+  }
+  if (typeof body?.count === 'number') {
+    agentsReturned.add(body.count, { fleet_size: String(fleetSize) });
+  }
+}
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy`);
+  }
+}
+
+export default function () {
+  for (const size of FLEET_SIZES) {
+    const t0 = Date.now();
+    resizeFleet(size);
+    sleep(PROPAGATION_S);
+    for (let i = 0; i < SAMPLES; i++) {
+      discoverOnce(size);
+    }
+    const stepDuration = (Date.now() - t0) / 1000;
+    // Print a per-step line so the operator can follow long sweeps in stdout.
+    console.log(`[step] fleet=${size} samples=${SAMPLES} step_seconds=${stepDuration.toFixed(1)}`);
+  }
+  // Tear down so the next scenario invocation starts clean.
+  const stopRes = http.post(`${BRIDGE_URL}/fleet/stop`, '{}', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  check(stopRes, { 'fleet stop ok': (r) => r.status === 200 });
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/discover_via_bridge.js
+++ b/packages/perf/k6/scenarios/discover_via_bridge.js
@@ -1,0 +1,81 @@
+// discover_via_bridge.js
+//
+// Sanity scenario for Phase 3: confirms that bridge -> @elisym/sdk -> relay
+// path works end-to-end, and produces a first discovery latency datapoint
+// against either the local strfry (no agents announced) or public relays.
+//
+// This is intentionally a low-RPS smoke. Q1 / Q2 (agent_fleet_scale,
+// web_discovery_latency) replace this with a structured sweep.
+
+import http from 'k6/http';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BRIDGE_URL, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const TARGET_RPS = intEnv('TARGET_RPS', 5);
+const DURATION_S = intEnv('DURATION_S', 30);
+const LIMIT = intEnv('AGENT_LIMIT', 50);
+const NETWORK = __ENV.NETWORK || 'devnet';
+
+const latency = new Trend('discover_call_ms', true);
+const bridgeOnly = new Trend('discover_bridge_elapsed_ms', true);
+const success = new Rate('discover_success_rate');
+const counts = new Counter('discover_agents_returned_total');
+
+export const options = {
+  scenarios: {
+    smoke: {
+      executor: 'constant-arrival-rate',
+      rate: TARGET_RPS,
+      timeUnit: '1s',
+      duration: `${DURATION_S}s`,
+      preAllocatedVUs: Math.max(5, TARGET_RPS),
+      maxVUs: Math.max(20, TARGET_RPS * 2),
+    },
+  },
+  thresholds: {
+    discover_call_ms: ['p(95)<5000'],
+    discover_success_rate: ['rate>0.9'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy (status ${probe.status})`);
+  }
+}
+
+export default function () {
+  const start = Date.now();
+  const res = http.post(
+    `${BRIDGE_URL}/discover`,
+    JSON.stringify({ network: NETWORK, limit: LIMIT }),
+    { headers: { 'Content-Type': 'application/json' }, timeout: '20s' },
+  );
+  const elapsed = Date.now() - start;
+  latency.add(elapsed);
+
+  const ok = res.status === 200;
+  success.add(ok);
+  if (!ok) {
+    return;
+  }
+  let body;
+  try {
+    body = res.json();
+  } catch (_err) {
+    return;
+  }
+  if (typeof body?.elapsedMs === 'number') {
+    bridgeOnly.add(body.elapsedMs);
+  }
+  if (typeof body?.count === 'number') {
+    counts.add(body.count);
+  }
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/e2e_steady_state.js
+++ b/packages/perf/k6/scenarios/e2e_steady_state.js
@@ -1,0 +1,136 @@
+// e2e_steady_state.js
+//
+// Q5: composite "realistic" steady-state load.
+//
+// What "realistic" means here is operator-tunable. The defaults paint a
+// picture of:
+//   - SUSTAINED_AGENTS = 500 synthetic agents online via the bridge fleet
+//   - DISCOVERY_RPS    = 5 user discovery queries / sec
+//   - JOB_RPS          = 1 paid job per minute (1/60 RPS) flooded at the provider
+//   - DURATION_MIN     = 10 minutes
+//
+// Run after agent_fleet_scale + provider_saturation have produced their
+// individual numbers. This scenario asks "do those numbers hold when the
+// system is doing all four headline activities simultaneously, for long
+// enough that drift / leaks would show?"
+//
+// Dashboards: open `e2e.json` in Grafana. The scenario writes its own k6
+// summary; provider/relay/bridge metrics are captured by Prometheus
+// throughout via the existing scrape config.
+
+import { check, sleep } from 'k6';
+import http from 'k6/http';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BRIDGE_URL, intEnv, floatEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const SUSTAINED_AGENTS = intEnv('SUSTAINED_AGENTS', 500);
+const DISCOVERY_RPS = intEnv('DISCOVERY_RPS', 5);
+const JOB_RPS = floatEnv('JOB_RPS', 1 / 60);
+const DURATION_MIN = intEnv('DURATION_MIN', 10);
+const NETWORK = __ENV.NETWORK || 'devnet';
+const CAPABILITY = __ENV.CAPABILITY || 'translate';
+
+const discoveryLatency = new Trend('discovery_call_ms', true);
+const jobSubmitLatency = new Trend('job_submit_call_ms', true);
+const discoveryOk = new Rate('discovery_success_rate');
+const jobSubmitOk = new Rate('job_submit_success_rate');
+const errors = new Counter('e2e_errors_total');
+
+const totalDuration = `${DURATION_MIN}m`;
+
+export const options = {
+  scenarios: {
+    fleet_keepalive: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: totalDuration,
+      exec: 'fleetKeepalive',
+    },
+    discovery: {
+      executor: 'constant-arrival-rate',
+      rate: DISCOVERY_RPS,
+      timeUnit: '1s',
+      duration: totalDuration,
+      preAllocatedVUs: Math.max(5, DISCOVERY_RPS),
+      maxVUs: Math.max(20, DISCOVERY_RPS * 4),
+      startTime: '15s',
+      exec: 'discover',
+    },
+    jobs: {
+      executor: 'constant-arrival-rate',
+      rate: Math.max(1, Math.round(JOB_RPS * 60)),
+      timeUnit: '1m',
+      duration: totalDuration,
+      preAllocatedVUs: 5,
+      maxVUs: 20,
+      startTime: '15s',
+      exec: 'submitJob',
+    },
+  },
+  thresholds: {
+    discovery_success_rate: ['rate>0.95'],
+    job_submit_success_rate: ['rate>0.95'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy`);
+  }
+}
+
+export function teardown() {
+  http.post(`${BRIDGE_URL}/fleet/stop`, '{}', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export function fleetKeepalive() {
+  const res = http.post(
+    `${BRIDGE_URL}/fleet/resize`,
+    JSON.stringify({ size: SUSTAINED_AGENTS, capability: CAPABILITY }),
+    { headers: { 'Content-Type': 'application/json' }, timeout: '180s' },
+  );
+  check(res, { 'fleet resize ok': (r) => r.status === 200 });
+  // Sleep until end of run; the fleet republishes itself every 2 minutes
+  // on its own cadence (see FleetSimulator).
+  sleep(DURATION_MIN * 60);
+}
+
+export function discover() {
+  const start = Date.now();
+  const res = http.post(`${BRIDGE_URL}/discover`, JSON.stringify({ network: NETWORK }), {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '20s',
+  });
+  const elapsed = Date.now() - start;
+  discoveryLatency.add(elapsed);
+  const ok = res.status === 200;
+  discoveryOk.add(ok);
+  if (!ok) {
+    errors.add(1, { kind: 'discover' });
+  }
+}
+
+export function submitJob() {
+  const start = Date.now();
+  const res = http.post(`${BRIDGE_URL}/job/submit`, JSON.stringify({ capability: CAPABILITY }), {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '15s',
+  });
+  const elapsed = Date.now() - start;
+  jobSubmitLatency.add(elapsed);
+  const ok = res.status === 200;
+  jobSubmitOk.add(ok);
+  if (!ok) {
+    errors.add(1, { kind: 'submit' });
+  }
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/mcp_discovery_latency.js
+++ b/packages/perf/k6/scenarios/mcp_discovery_latency.js
@@ -1,0 +1,138 @@
+// mcp_discovery_latency.js
+//
+// Q3: how fast is `discover_agents` in MCP?
+//
+// Methodology:
+//   - One bridge process holds one MCP child (single shared session, like a
+//     real assistant client).
+//   - For each fleet size in FLEET_SIZES, repeat:
+//       1. POST /fleet/resize { size }
+//       2. Sleep PROPAGATION_S
+//       3. POST /mcp/call { tool: 'discover_agents', args: {...} } x SAMPLES
+//   - Records p50/p95/p99 of MCP-tool latency, separately from bridge overhead.
+//
+// Single VU, sequential by design (stdio is synchronous).
+//
+// Pre-conditions:
+//   - bridge running with MCP_AGENT=<name> (or pass `agent` in /mcp/start body).
+//   - elisym-mcp on PATH (built from packages/mcp), or set MCP_COMMAND.
+//   - elisym agent <name> exists (run `elisym init <name>` once).
+
+import { check, sleep } from 'k6';
+import http from 'k6/http';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BRIDGE_URL, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const SAMPLES = intEnv('SAMPLES', 20);
+const PROPAGATION_S = intEnv('PROPAGATION_S', 5);
+const NETWORK = __ENV.NETWORK || 'devnet';
+const CAPABILITY = __ENV.CAPABILITY || 'translate';
+const AGENT_LIMIT = intEnv('AGENT_LIMIT', 50);
+const MCP_AGENT = __ENV.MCP_AGENT || '';
+const MCP_COMMAND = __ENV.MCP_COMMAND || 'elisym-mcp';
+const FLEET_SIZES = (__ENV.FLEET_SIZES || '0,50,500,2000')
+  .split(',')
+  .map((s) => Number.parseInt(s.trim(), 10))
+  .filter((n) => Number.isInteger(n) && n >= 0);
+
+const mcpLatency = new Trend('mcp_call_ms', true);
+const mcpToolErrors = new Counter('mcp_tool_errors_total');
+const mcpHttpErrors = new Counter('mcp_http_errors_total');
+const success = new Rate('mcp_success_rate');
+
+export const options = {
+  scenarios: {
+    sweep: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '30m',
+    },
+  },
+  thresholds: {
+    mcp_success_rate: ['rate>0.95'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy`);
+  }
+  const startBody = JSON.stringify({
+    agent: MCP_AGENT || undefined,
+    command: MCP_COMMAND,
+  });
+  const startRes = http.post(`${BRIDGE_URL}/mcp/start`, startBody, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '15s',
+  });
+  if (startRes.status !== 200) {
+    throw new Error(`mcp/start failed (${startRes.status}): ${startRes.body}`);
+  }
+}
+
+export function teardown() {
+  http.post(`${BRIDGE_URL}/mcp/stop`, '{}', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function discoverOnce(fleetSize) {
+  const body = JSON.stringify({
+    tool: 'discover_agents',
+    args: { capability: CAPABILITY, limit: AGENT_LIMIT, network: NETWORK },
+  });
+  const res = http.post(`${BRIDGE_URL}/mcp/call`, body, {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '60s',
+  });
+  if (res.status !== 200) {
+    mcpHttpErrors.add(1, { fleet_size: String(fleetSize) });
+    success.add(false);
+    return;
+  }
+  let parsed;
+  try {
+    parsed = res.json();
+  } catch (_err) {
+    mcpHttpErrors.add(1, { fleet_size: String(fleetSize) });
+    success.add(false);
+    return;
+  }
+  const ok = parsed?.ok === true;
+  success.add(ok, { fleet_size: String(fleetSize) });
+  if (typeof parsed?.elapsedMs === 'number') {
+    mcpLatency.add(parsed.elapsedMs, { fleet_size: String(fleetSize) });
+  }
+  if (parsed?.isToolError) {
+    mcpToolErrors.add(1, { fleet_size: String(fleetSize) });
+  }
+}
+
+export default function () {
+  for (const size of FLEET_SIZES) {
+    const t0 = Date.now();
+    const resizeRes = http.post(
+      `${BRIDGE_URL}/fleet/resize`,
+      JSON.stringify({ size, capability: CAPABILITY }),
+      { headers: { 'Content-Type': 'application/json' }, timeout: '120s' },
+    );
+    check(resizeRes, { 'fleet resize 200': (r) => r.status === 200 });
+    sleep(PROPAGATION_S);
+    for (let i = 0; i < SAMPLES; i++) {
+      discoverOnce(size);
+    }
+    const stepDuration = (Date.now() - t0) / 1000;
+    console.log(`[step] fleet=${size} samples=${SAMPLES} step_seconds=${stepDuration.toFixed(1)}`);
+  }
+  http.post(`${BRIDGE_URL}/fleet/stop`, '{}', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/mcp_discovery_latency.js
+++ b/packages/perf/k6/scenarios/mcp_discovery_latency.js
@@ -81,9 +81,15 @@ export function teardown() {
 }
 
 function discoverOnce(fleetSize) {
+  // The MCP tool is `search_agents` (see packages/mcp/src/tools/discovery.ts).
+  // Schema: { capabilities: string[], include_offline?: boolean, ... }. The
+  // active network is read from the agent's elisym.yaml, not from args.
+  // include_offline=true skips the live online probe so synthetic fleet
+  // members (which only publish kind:20200 every 30s) are not filtered out
+  // while pings are still warming up.
   const body = JSON.stringify({
-    tool: 'discover_agents',
-    args: { capability: CAPABILITY, limit: AGENT_LIMIT, network: NETWORK },
+    tool: 'search_agents',
+    args: { capabilities: [CAPABILITY], include_offline: true },
   });
   const res = http.post(`${BRIDGE_URL}/mcp/call`, body, {
     headers: { 'Content-Type': 'application/json' },

--- a/packages/perf/k6/scenarios/protocol_config_cache.js
+++ b/packages/perf/k6/scenarios/protocol_config_cache.js
@@ -1,0 +1,87 @@
+// protocol_config_cache.js
+//
+// Verifies the 60s TTL cache effectiveness in @elisym/sdk's getProtocolConfig.
+// Hits the bridge's /protocol-config endpoint at high frequency and measures:
+//   - p95 latency (cache hits should be sub-ms-side, network calls dominate cold).
+//   - whether bridge metric `elisym_bridge_call_duration_seconds` matches k6
+//     side latency (sanity check that bridge does not become the bottleneck).
+//
+// Default knobs are deliberately conservative so you can run this against a
+// freshly booted test-validator without exhausting the program's read budget.
+
+import { check } from 'k6';
+import http from 'k6/http';
+import { Counter, Trend, Rate } from 'k6/metrics';
+import { BRIDGE_URL, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const TARGET_RPS = intEnv('TARGET_RPS', 50);
+const DURATION_S = intEnv('DURATION_S', 60);
+const NETWORK = __ENV.NETWORK || 'devnet';
+
+const latency = new Trend('config_call_ms', true);
+const bridgeOnly = new Trend('config_bridge_elapsed_ms', true);
+const errors = new Counter('config_errors_total');
+const ok = new Rate('config_success_rate');
+
+export const options = {
+  scenarios: {
+    burst: {
+      executor: 'constant-arrival-rate',
+      rate: TARGET_RPS,
+      timeUnit: '1s',
+      duration: `${DURATION_S}s`,
+      preAllocatedVUs: Math.max(10, Math.ceil(TARGET_RPS / 5)),
+      maxVUs: Math.max(50, TARGET_RPS),
+    },
+  },
+  thresholds: {
+    config_call_ms: ['p(95)<200', 'p(99)<1000'],
+    config_success_rate: ['rate>0.99'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy (status ${probe.status})`);
+  }
+  return { bridgeUrl: BRIDGE_URL };
+}
+
+export default function () {
+  const start = Date.now();
+  const res = http.post(`${BRIDGE_URL}/protocol-config`, JSON.stringify({ network: NETWORK }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const elapsed = Date.now() - start;
+
+  const success = res.status === 200;
+  ok.add(success);
+  latency.add(elapsed);
+  if (!success) {
+    errors.add(1);
+    return;
+  }
+  let body;
+  try {
+    body = res.json();
+  } catch (_err) {
+    errors.add(1);
+    return;
+  }
+  if (typeof body?.elapsedMs === 'number') {
+    bridgeOnly.add(body.elapsedMs);
+  }
+  check(res, {
+    'protocol-config returns config': (r) => {
+      const j = r.json();
+      return Boolean(j?.config);
+    },
+  });
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/provider_saturation.js
+++ b/packages/perf/k6/scenarios/provider_saturation.js
@@ -3,8 +3,12 @@
 // Q4: how many concurrent jobs does one provider hold?
 //
 // Methodology:
-//   - Constant-arrival-rate flood of broadcast job requests via bridge
+//   - Constant-arrival-rate flood of targeted job requests via bridge
 //     /job/submit. Submission RPS ramps via stages so we observe the curve.
+//   - PROVIDER_PUBKEY env is REQUIRED. The SDK's `subscribeToJobRequests`
+//     only delivers events whose `p` tag matches the provider's own pubkey;
+//     untargeted broadcasts are filtered out by the relay. Pass the hex
+//     pubkey of the running provider (find via `elisym list`).
 //   - Provider runs separately on host with `MOCK_LLM=1 elisym start <name>
 //     --metrics-port 9464`. Prometheus scrapes its /metrics, so the answer
 //     reads off the provider.json Grafana dashboard, not k6 output.
@@ -27,6 +31,7 @@ const STAGE_RPS = (__ENV.STAGE_RPS || '1,5,15,30,60')
   .map((s) => Number.parseInt(s.trim(), 10))
   .filter((n) => Number.isInteger(n) && n > 0);
 const CAPABILITY = __ENV.CAPABILITY || 'translate';
+const PROVIDER_PUBKEY = __ENV.PROVIDER_PUBKEY || '';
 
 const submitLatency = new Trend('submit_call_ms', true);
 const submitErrors = new Counter('submit_errors_total');
@@ -62,6 +67,11 @@ export const options = {
 };
 
 export function setup() {
+  if (!PROVIDER_PUBKEY) {
+    throw new Error(
+      'PROVIDER_PUBKEY env is required (64-char hex). Find it via `./packages/cli/dist/index.js list`.',
+    );
+  }
   const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
   if (probe.status !== 200) {
     throw new Error(`bridge ${BRIDGE_URL} not healthy`);
@@ -70,10 +80,14 @@ export function setup() {
 
 export function submit() {
   const start = Date.now();
-  const res = http.post(`${BRIDGE_URL}/job/submit`, JSON.stringify({ capability: CAPABILITY }), {
-    headers: { 'Content-Type': 'application/json' },
-    timeout: '15s',
-  });
+  const res = http.post(
+    `${BRIDGE_URL}/job/submit`,
+    JSON.stringify({ capability: CAPABILITY, providerPubkey: PROVIDER_PUBKEY }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      timeout: '15s',
+    },
+  );
   const elapsed = Date.now() - start;
   submitLatency.add(elapsed);
   const ok = res.status === 200;

--- a/packages/perf/k6/scenarios/provider_saturation.js
+++ b/packages/perf/k6/scenarios/provider_saturation.js
@@ -1,0 +1,88 @@
+// provider_saturation.js
+//
+// Q4: how many concurrent jobs does one provider hold?
+//
+// Methodology:
+//   - Constant-arrival-rate flood of broadcast job requests via bridge
+//     /job/submit. Submission RPS ramps via stages so we observe the curve.
+//   - Provider runs separately on host with `MOCK_LLM=1 elisym start <name>
+//     --metrics-port 9464`. Prometheus scrapes its /metrics, so the answer
+//     reads off the provider.json Grafana dashboard, not k6 output.
+//   - k6 measures only submission-side latency: how fast can we hand the
+//     relay a kind:5100 event. Real "time-to-result" is observed via the
+//     provider metric `elisym_job_duration_seconds`.
+//
+// Interpretation: the queue-depth knee is where `elisym_jobs_in_flight`
+// pegs at MAX_CONCURRENT_JOBS (=10) and `elisym_jobs_pending` starts to
+// climb monotonically.
+
+import http from 'k6/http';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BRIDGE_URL, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const STAGE_S = intEnv('STAGE_S', 30);
+const STAGE_RPS = (__ENV.STAGE_RPS || '1,5,15,30,60')
+  .split(',')
+  .map((s) => Number.parseInt(s.trim(), 10))
+  .filter((n) => Number.isInteger(n) && n > 0);
+const CAPABILITY = __ENV.CAPABILITY || 'translate';
+
+const submitLatency = new Trend('submit_call_ms', true);
+const submitErrors = new Counter('submit_errors_total');
+const submitOk = new Rate('submit_success_rate');
+
+function stage(rps, startTimeS) {
+  return {
+    executor: 'constant-arrival-rate',
+    rate: rps,
+    timeUnit: '1s',
+    duration: `${STAGE_S}s`,
+    preAllocatedVUs: Math.max(20, Math.ceil(rps * 1.5)),
+    maxVUs: Math.max(50, rps * 4),
+    startTime: `${startTimeS}s`,
+    exec: 'submit',
+    tags: { stage_rps: String(rps) },
+  };
+}
+
+const scenarios = {};
+let cursor = 0;
+for (const rps of STAGE_RPS) {
+  scenarios[`rps_${rps}`] = stage(rps, cursor);
+  cursor += STAGE_S + 5;
+}
+
+export const options = {
+  scenarios,
+  thresholds: {
+    submit_success_rate: ['rate>0.95'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy`);
+  }
+}
+
+export function submit() {
+  const start = Date.now();
+  const res = http.post(`${BRIDGE_URL}/job/submit`, JSON.stringify({ capability: CAPABILITY }), {
+    headers: { 'Content-Type': 'application/json' },
+    timeout: '15s',
+  });
+  const elapsed = Date.now() - start;
+  submitLatency.add(elapsed);
+  const ok = res.status === 200;
+  submitOk.add(ok);
+  if (!ok) {
+    submitErrors.add(1);
+  }
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/relay_publish.js
+++ b/packages/perf/k6/scenarios/relay_publish.js
@@ -1,0 +1,110 @@
+// relay_publish.js
+//
+// Phase 1 baseline: how many EVENTs/sec can our local strfry accept?
+//
+// Methodology:
+//   - Pre-signed fixture of N events (generated via packages/perf/scripts/generate-events.ts).
+//   - VUs ramp from 1 to TARGET_VUS over WARMUP_S, hold for HOLD_S, ramp down.
+//   - Each VU opens one ws connection, publishes events at MAX_VU_RATE evt/sec,
+//     measures the OK ack round-trip latency, records both accepted and rejected
+//     outcomes. Pre-signed events should all be accepted; rejection signals a bug
+//     in the fixture generator or strfry config drift.
+//
+// Knobs (env):
+//   STRFRY_WS=ws://localhost:7777   target relay
+//   FIXTURE=/fixtures/events-5100.json (path inside the container OR absolute on host)
+//   TARGET_VUS=50
+//   WARMUP_S=15
+//   HOLD_S=60
+//   COOLDOWN_S=10
+//   MAX_VU_RATE=20                  events per second per VU
+
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import ws from 'k6/ws';
+import { STRFRY_WS, intEnv } from '../lib/env.js';
+import { publishEvent } from '../lib/nostr.js';
+import { writeSummary } from '../lib/stats.js';
+
+// Path is resolved relative to THIS scenario file by k6's open(); the
+// FIXTURE env-var lets a runner inject an absolute path if needed.
+const FIXTURE = __ENV.FIXTURE || '../fixtures/events-5100.json';
+const TARGET_VUS = intEnv('TARGET_VUS', 50);
+const WARMUP_S = intEnv('WARMUP_S', 15);
+const HOLD_S = intEnv('HOLD_S', 60);
+const COOLDOWN_S = intEnv('COOLDOWN_S', 10);
+const MAX_VU_RATE = intEnv('MAX_VU_RATE', 20);
+
+const events = new SharedArray('events', () => {
+  const raw = open(FIXTURE);
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(`fixture ${FIXTURE} is empty or not an array`);
+  }
+  return parsed;
+});
+
+const okLatency = new Trend('relay_ok_latency_ms', true);
+const acks = new Counter('relay_acks_total');
+const rejects = new Counter('relay_rejects_total');
+const sent = new Counter('relay_sent_total');
+const errors = new Counter('relay_errors_total');
+const acceptRate = new Rate('relay_accept_rate');
+
+export const options = {
+  scenarios: {
+    publish: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: `${WARMUP_S}s`, target: TARGET_VUS },
+        { duration: `${HOLD_S}s`, target: TARGET_VUS },
+        { duration: `${COOLDOWN_S}s`, target: 0 },
+      ],
+      gracefulRampDown: '5s',
+    },
+  },
+  thresholds: {
+    relay_ok_latency_ms: ['p(95)<500', 'p(99)<2000'],
+    relay_accept_rate: ['rate>0.99'],
+    relay_errors_total: ['count<10'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export default function () {
+  const periodMs = Math.max(1, Math.floor(1000 / MAX_VU_RATE));
+  let cursor = (__VU * 7919 + __ITER) % events.length;
+
+  const res = ws.connect(STRFRY_WS, {}, (socket) => {
+    socket.on('open', () => {
+      const tickerEnd = Date.now() + 1000;
+      while (Date.now() < tickerEnd) {
+        const event = events[cursor];
+        cursor = (cursor + 1) % events.length;
+        publishEvent(socket, event, {
+          okTrend: okLatency,
+          sentCounter: sent,
+          ackCounter: acks,
+          errorCounter: rejects,
+          onResolve: (_id, accepted) => {
+            acceptRate.add(accepted);
+          },
+        });
+        sleep(periodMs / 1000);
+      }
+      socket.close();
+    });
+
+    socket.on('error', () => {
+      errors.add(1);
+    });
+  });
+
+  check(res, { 'ws handshake 101': (r) => r && r.status === 101 });
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/relay_publish.js
+++ b/packages/perf/k6/scenarios/relay_publish.js
@@ -5,10 +5,11 @@
 // Methodology:
 //   - Pre-signed fixture of N events (generated via packages/perf/scripts/generate-events.ts).
 //   - VUs ramp from 1 to TARGET_VUS over WARMUP_S, hold for HOLD_S, ramp down.
-//   - Each VU opens one ws connection, publishes events at MAX_VU_RATE evt/sec,
-//     measures the OK ack round-trip latency, records both accepted and rejected
-//     outcomes. Pre-signed events should all be accepted; rejection signals a bug
-//     in the fixture generator or strfry config drift.
+//   - Each VU opens one ws connection for ITER_DURATION_S, drives sends at
+//     MAX_VU_RATE evt/sec via socket.setInterval (non-blocking — leaves the
+//     k6 event loop free to dispatch OK frames). A single message handler
+//     installed via createOkRouter resolves each pending event when its OK
+//     arrives, recording accept/reject and round-trip latency.
 //
 // Knobs (env):
 //   STRFRY_WS=ws://localhost:7777   target relay
@@ -18,13 +19,15 @@
 //   HOLD_S=60
 //   COOLDOWN_S=10
 //   MAX_VU_RATE=20                  events per second per VU
+//   ITER_DURATION_S=5               seconds each iteration holds the socket
+//   OK_GRACE_MS=2000                grace window after send-stop for late OKs
 
-import { check, sleep } from 'k6';
+import { check } from 'k6';
 import { SharedArray } from 'k6/data';
 import { Counter, Rate, Trend } from 'k6/metrics';
 import ws from 'k6/ws';
 import { STRFRY_WS, intEnv } from '../lib/env.js';
-import { publishEvent } from '../lib/nostr.js';
+import { createOkRouter } from '../lib/nostr.js';
 import { writeSummary } from '../lib/stats.js';
 
 // Path is resolved relative to THIS scenario file by k6's open(); the
@@ -35,6 +38,8 @@ const WARMUP_S = intEnv('WARMUP_S', 15);
 const HOLD_S = intEnv('HOLD_S', 60);
 const COOLDOWN_S = intEnv('COOLDOWN_S', 10);
 const MAX_VU_RATE = intEnv('MAX_VU_RATE', 20);
+const ITER_DURATION_S = intEnv('ITER_DURATION_S', 5);
+const OK_GRACE_MS = intEnv('OK_GRACE_MS', 2000);
 
 const events = new SharedArray('events', () => {
   const raw = open(FIXTURE);
@@ -50,6 +55,7 @@ const acks = new Counter('relay_acks_total');
 const rejects = new Counter('relay_rejects_total');
 const sent = new Counter('relay_sent_total');
 const errors = new Counter('relay_errors_total');
+const timeouts = new Counter('relay_timeouts_total');
 const acceptRate = new Rate('relay_accept_rate');
 
 export const options = {
@@ -79,22 +85,38 @@ export default function () {
 
   const res = ws.connect(STRFRY_WS, {}, (socket) => {
     socket.on('open', () => {
-      const tickerEnd = Date.now() + 1000;
-      while (Date.now() < tickerEnd) {
+      const router = createOkRouter(socket, {
+        okTrend: okLatency,
+        sentCounter: sent,
+        ackCounter: acks,
+        errorCounter: rejects,
+        onResolve: (_id, accepted) => {
+          acceptRate.add(accepted);
+        },
+      });
+
+      // k6/ws Socket has no clearInterval. Gate the interval body on a
+      // `stopped` flag so the send-loop becomes a no-op once we enter the
+      // grace window, then close the socket to terminate it for good.
+      let stopped = false;
+      socket.setInterval(() => {
+        if (stopped) return;
         const event = events[cursor];
         cursor = (cursor + 1) % events.length;
-        publishEvent(socket, event, {
-          okTrend: okLatency,
-          sentCounter: sent,
-          ackCounter: acks,
-          errorCounter: rejects,
-          onResolve: (_id, accepted) => {
-            acceptRate.add(accepted);
-          },
-        });
-        sleep(periodMs / 1000);
-      }
-      socket.close();
+        router.publish(event);
+      }, periodMs);
+
+      socket.setTimeout(() => {
+        stopped = true;
+        socket.setTimeout(() => {
+          const stillPending = router.flush('iteration-timeout');
+          if (stillPending > 0) {
+            timeouts.add(stillPending);
+            for (let i = 0; i < stillPending; i++) acceptRate.add(false);
+          }
+          socket.close();
+        }, OK_GRACE_MS);
+      }, ITER_DURATION_S * 1000);
     });
 
     socket.on('error', () => {

--- a/packages/perf/k6/scenarios/relay_subscribe_fanout.js
+++ b/packages/perf/k6/scenarios/relay_subscribe_fanout.js
@@ -1,0 +1,140 @@
+// relay_subscribe_fanout.js
+//
+// Diagnostic sub-scenario for Q2: holds N WebSocket subscribers open against
+// strfry, then publishes M events via a single producer connection. Measures
+// fanout latency: "how long until X% of subscribers receive each event?"
+//
+// Knobs:
+//   SUBSCRIBERS=200
+//   PUBLISH_BATCH=20
+//   PUBLISH_INTERVAL_MS=500
+//   STAGE_S=60
+//   FIXTURE=../fixtures/events-5100.json (auto-generated)
+
+import { sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Trend, Counter, Rate } from 'k6/metrics';
+import ws from 'k6/ws';
+import { STRFRY_WS, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const FIXTURE = __ENV.FIXTURE || '../fixtures/events-5100.json';
+const SUBSCRIBERS = intEnv('SUBSCRIBERS', 200);
+const PUBLISH_BATCH = intEnv('PUBLISH_BATCH', 20);
+const PUBLISH_INTERVAL_MS = intEnv('PUBLISH_INTERVAL_MS', 500);
+const STAGE_S = intEnv('STAGE_S', 60);
+
+const events = new SharedArray('events', () => {
+  const raw = open(FIXTURE);
+  return JSON.parse(raw);
+});
+
+const fanoutLatency = new Trend('fanout_delivery_ms', true);
+const subscriberDrops = new Counter('subscriber_drops_total');
+const publishesTotal = new Counter('publishes_total');
+const eventsReceivedTotal = new Counter('events_received_total');
+const subscriberOpenRate = new Rate('subscriber_open_rate');
+
+// Two scenarios: subscribers (long-lived) + publisher (short bursts).
+export const options = {
+  scenarios: {
+    subscribers: {
+      executor: 'per-vu-iterations',
+      vus: SUBSCRIBERS,
+      iterations: 1,
+      maxDuration: `${STAGE_S + 10}s`,
+      exec: 'subscriber',
+    },
+    publisher: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      startTime: '5s',
+      maxDuration: `${STAGE_S + 5}s`,
+      exec: 'publisher',
+    },
+  },
+  thresholds: {
+    fanout_delivery_ms: ['p(95)<1000', 'p(99)<3000'],
+    subscriber_open_rate: ['rate>0.95'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function subscriber() {
+  const subId = `sub-${__VU}`;
+  const filter = { kinds: [5100], '#t': ['perf-fanout'] };
+  const res = ws.connect(STRFRY_WS, {}, (socket) => {
+    socket.on('open', () => {
+      subscriberOpenRate.add(true);
+      socket.send(JSON.stringify(['REQ', subId, filter]));
+    });
+    socket.on('message', (raw) => {
+      let parsed;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (_err) {
+        return;
+      }
+      if (Array.isArray(parsed) && parsed[0] === 'EVENT' && parsed[1] === subId) {
+        eventsReceivedTotal.add(1);
+        const event = parsed[2];
+        if (event && typeof event.created_at === 'number') {
+          // Producer stamps the publish wall-clock into the content as
+          // `t=<ms>`; if absent, fall back to created_at-based estimate.
+          const matched = /t=(\d+)/.exec(String(event.content ?? ''));
+          if (matched) {
+            const t0 = Number.parseInt(matched[1], 10);
+            fanoutLatency.add(Date.now() - t0);
+          }
+        }
+      }
+    });
+    socket.on('close', () => {
+      subscriberDrops.add(1);
+    });
+    socket.setTimeout(() => {
+      socket.send(JSON.stringify(['CLOSE', subId]));
+      socket.close();
+    }, STAGE_S * 1000);
+  });
+  if (!res || res.status !== 101) {
+    subscriberOpenRate.add(false);
+  }
+}
+
+export function publisher() {
+  const res = ws.connect(STRFRY_WS, {}, (socket) => {
+    socket.on('open', () => {
+      const endTime = Date.now() + STAGE_S * 1000;
+      while (Date.now() < endTime) {
+        for (let i = 0; i < PUBLISH_BATCH; i++) {
+          // Pick a fixture event but rewrite the content to embed the wall-clock
+          // timestamp so subscribers can compute delivery latency without
+          // requiring synchronised clocks (single host, same epoch).
+          const base = events[Math.floor(Math.random() * events.length)];
+          const stamped = {
+            ...base,
+            content: `${base.content} | t=${Date.now()}`,
+            tags: [...base.tags, ['t', 'perf-fanout']],
+          };
+          // NOTE: stamped event has wrong sig now, but strfry rejects it.
+          // For accurate fanout, regenerate fixture with the perf-fanout
+          // tag baked in via generate-events.ts. This is a Phase 5 follow-up
+          // captured in README troubleshooting.
+          socket.send(JSON.stringify(['EVENT', stamped]));
+          publishesTotal.add(1);
+        }
+        sleep(PUBLISH_INTERVAL_MS / 1000);
+      }
+      socket.close();
+    });
+  });
+  if (!res || res.status !== 101) {
+    throw new Error(`publisher could not connect to ${STRFRY_WS}`);
+  }
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/solana_rpc_burst.js
+++ b/packages/perf/k6/scenarios/solana_rpc_burst.js
@@ -1,0 +1,87 @@
+// solana_rpc_burst.js
+//
+// Q3 sub-scenario: how does our RPC layer hold under burst?
+// Useful as a baseline before payment_full_flow runs - if the RPC itself is
+// the bottleneck, the SDK numbers will be misleading.
+//
+// Methodology:
+//   - Three RPS shapes (light, medium, heavy) issued with constant-arrival-rate.
+//   - Per-method tagging: getSlot, getBlockHeight, getLatestBlockhash, getBalance.
+//   - Records latency per method, error rate, 429 rate.
+//
+// Defaults are set for solana-test-validator on localhost:8899. Pass
+// RPC_URL=https://api.devnet.solana.com to retarget at devnet (be gentle).
+
+import { Trend, Counter, Rate } from 'k6/metrics';
+import { RPC_URL, intEnv } from '../lib/env.js';
+import { rpcCall, pingRpc } from '../lib/solana-rpc.js';
+import { writeSummary } from '../lib/stats.js';
+
+const PROBE_ADDRESS = __ENV.PROBE_ADDRESS || 'Vote111111111111111111111111111111111111111';
+const HEAVY_RPS = intEnv('HEAVY_RPS', 200);
+const MEDIUM_RPS = intEnv('MEDIUM_RPS', 100);
+const LIGHT_RPS = intEnv('LIGHT_RPS', 25);
+const STAGE_S = intEnv('STAGE_S', 30);
+
+const latency = new Trend('rpc_latency_ms', true);
+const errors = new Counter('rpc_errors_total');
+const ratelimits = new Counter('rpc_ratelimit_total');
+const successRate = new Rate('rpc_success_rate');
+
+export const options = {
+  scenarios: {
+    light: rate(LIGHT_RPS, STAGE_S, 0),
+    medium: rate(MEDIUM_RPS, STAGE_S, STAGE_S + 5),
+    heavy: rate(HEAVY_RPS, STAGE_S, (STAGE_S + 5) * 2),
+  },
+  thresholds: {
+    rpc_latency_ms: ['p(95)<500', 'p(99)<2000'],
+    rpc_success_rate: ['rate>0.95'],
+    rpc_ratelimit_total: ['count<50'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+function rate(rps, durationSeconds, startSeconds) {
+  return {
+    executor: 'constant-arrival-rate',
+    rate: rps,
+    timeUnit: '1s',
+    duration: `${durationSeconds}s`,
+    preAllocatedVUs: Math.max(10, Math.ceil(rps / 5)),
+    maxVUs: Math.max(50, rps),
+    startTime: `${startSeconds}s`,
+    exec: 'oneRequest',
+  };
+}
+
+export function setup() {
+  const ok = pingRpc(RPC_URL);
+  if (!ok) {
+    throw new Error(
+      `RPC ${RPC_URL} did not respond to getHealth - is solana-test-validator running?`,
+    );
+  }
+  return { rpcUrl: RPC_URL };
+}
+
+const METHODS = ['getSlot', 'getBlockHeight', 'getLatestBlockhash', 'getBalance'];
+
+export function oneRequest() {
+  const method = METHODS[__ITER % METHODS.length];
+  const params = method === 'getBalance' ? [PROBE_ADDRESS] : [];
+  const r = rpcCall(method, params);
+  latency.add(r.durationMs, { method });
+  if (r.status === 429) {
+    ratelimits.add(1);
+  }
+  const ok = r.status === 200 && !r.error;
+  successRate.add(ok);
+  if (!ok) {
+    errors.add(1);
+  }
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/k6/scenarios/web_discovery_latency.js
+++ b/packages/perf/k6/scenarios/web_discovery_latency.js
@@ -1,0 +1,113 @@
+// web_discovery_latency.js
+//
+// Q2: how fast does an end user see search results in the web app?
+//
+// Mirrors what `packages/app` does on cold start: subscribe to NIP-89 events
+// via `streamAgents`, render cards as they arrive, fire enrichment on EOSE.
+// The bridge's /stream-discover endpoint exposes this exact sequence with
+// server-measured timestamps so we can report:
+//
+//   - time-to-first-card (TTF): first onAgent callback
+//   - time-to-N-cards     (TTN): first time count >= TARGET_AGENTS_N
+//   - time-to-EOSE        (TTE): all relays replied
+//   - time-to-complete    (TTC): enrichment done, ranking finalised
+//
+// Designed to run AFTER /fleet/resize has populated the relay (e.g. 500
+// agents). Run agent_fleet_scale first or invoke /fleet/resize manually.
+//
+// Cold-cache only for now. Browser-side warm-cache (IndexedDB hit) is a
+// separate optional scenario `web_browser_smoke.js` that drives a real
+// vite preview - meaningful when there's a real persistent cache.
+
+import http from 'k6/http';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BRIDGE_URL, intEnv } from '../lib/env.js';
+import { writeSummary } from '../lib/stats.js';
+
+const VUS = intEnv('VUS', 10);
+const ITERATIONS_PER_VU = intEnv('ITERATIONS_PER_VU', 5);
+const TIMEOUT_MS = intEnv('TIMEOUT_MS', 30_000);
+const TARGET_AGENTS_N = intEnv('TARGET_AGENTS_N', 10);
+const SAMPLE_EVERY_N = intEnv('SAMPLE_EVERY_N', TARGET_AGENTS_N);
+const NETWORK = __ENV.NETWORK || 'devnet';
+
+const ttf = new Trend('ttf_first_card_ms', true);
+const ttn = new Trend('ttn_n_cards_ms', true);
+const tte = new Trend('tte_eose_ms', true);
+const ttc = new Trend('ttc_complete_ms', true);
+const finalCount = new Trend('final_agent_count');
+const timeouts = new Counter('stream_timeouts_total');
+const success = new Rate('stream_success_rate');
+
+export const options = {
+  scenarios: {
+    cold: {
+      executor: 'per-vu-iterations',
+      vus: VUS,
+      iterations: ITERATIONS_PER_VU,
+      maxDuration: '15m',
+    },
+  },
+  thresholds: {
+    stream_success_rate: ['rate>0.95'],
+    ttf_first_card_ms: ['p(95)<5000'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(50)', 'p(95)', 'p(99)'],
+};
+
+export function setup() {
+  const probe = http.get(`${BRIDGE_URL}/healthz`, { timeout: '2s' });
+  if (probe.status !== 200) {
+    throw new Error(`bridge ${BRIDGE_URL} not healthy`);
+  }
+}
+
+export default function () {
+  const res = http.post(
+    `${BRIDGE_URL}/stream-discover`,
+    JSON.stringify({ network: NETWORK, timeoutMs: TIMEOUT_MS, sampleEveryN: SAMPLE_EVERY_N }),
+    { headers: { 'Content-Type': 'application/json' }, timeout: `${TIMEOUT_MS + 5000}ms` },
+  );
+
+  const ok = res.status === 200;
+  success.add(ok);
+  if (!ok) {
+    return;
+  }
+
+  let body;
+  try {
+    body = res.json();
+  } catch (_err) {
+    return;
+  }
+
+  if (typeof body?.firstAgentDeltaMs === 'number') {
+    ttf.add(body.firstAgentDeltaMs);
+  }
+  if (typeof body?.finalCount === 'number') {
+    finalCount.add(body.finalCount);
+  }
+  if (body?.timedOut) {
+    timeouts.add(1);
+  }
+
+  const milestones = Array.isArray(body?.milestones) ? body.milestones : [];
+  for (const m of milestones) {
+    if (m.event === 'eose' && typeof m.deltaMs === 'number') {
+      tte.add(m.deltaMs);
+    } else if (m.event === 'complete' && typeof m.deltaMs === 'number') {
+      ttc.add(m.deltaMs);
+    } else if (
+      m.event === 'n-agents' &&
+      typeof m.deltaMs === 'number' &&
+      m.index === TARGET_AGENTS_N
+    ) {
+      ttn.add(m.deltaMs);
+    }
+  }
+}
+
+export function handleSummary(data) {
+  return writeSummary(data);
+}

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@elisym/perf",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Local capacity tests for elisym (Nostr relay, Solana RPC, SDK, CLI provider, MCP). Not published.",
+  "type": "module",
+  "scripts": {
+    "stack:up": "./scripts/stack-up.sh",
+    "stack:down": "./scripts/stack-down.sh",
+    "run": "./scripts/run.sh",
+    "bridge": "bun --hot bridge/src/server.ts",
+    "validator": "./scripts/start-validator.sh",
+    "build": "echo 'no build for @elisym/perf'",
+    "test": "echo 'no unit tests for @elisym/perf'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf k6/reports/*.json k6/reports/*.html"
+  },
+  "dependencies": {
+    "@elisym/sdk": "workspace:*",
+    "@modelcontextprotocol/sdk": "~1.21.0",
+    "@solana/kit": "~6.8.0",
+    "hono": "~4.7.0",
+    "nostr-tools": "~2.23.0",
+    "prom-client": "~15.1.0"
+  },
+  "devDependencies": {
+    "@types/bun": "~1.3.0",
+    "@types/node": "~22.0.0",
+    "typescript": "~5.7.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/perf/scripts/generate-events.ts
+++ b/packages/perf/scripts/generate-events.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env bun
+/**
+ * Pre-sign a fixture of NIP-01 events for k6 ws scenarios.
+ *
+ * Why: k6 cannot sign schnorr/secp256k1 events natively. Pre-generating events
+ * with nostr-tools also keeps k6 measuring relay throughput rather than crypto
+ * cost on the load-generator side.
+ *
+ * Output: packages/perf/k6/fixtures/events-<kind>.json
+ *
+ * Usage:
+ *   bun packages/perf/scripts/generate-events.ts --kind 5100 --count 5000
+ *   bun packages/perf/scripts/generate-events.ts --kind 31990 --count 1000 --capability translate
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+
+interface Args {
+  kind: number;
+  count: number;
+  capability: string;
+  out: string;
+  seedKeys: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Partial<Args> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    switch (flag) {
+      case '--kind':
+        args.kind = Number.parseInt(value ?? '', 10);
+        i++;
+        break;
+      case '--count':
+        args.count = Number.parseInt(value ?? '', 10);
+        i++;
+        break;
+      case '--capability':
+        args.capability = value ?? 'translate';
+        i++;
+        break;
+      case '--out':
+        args.out = value ?? '';
+        i++;
+        break;
+      case '--seed-keys':
+        args.seedKeys = Number.parseInt(value ?? '', 10);
+        i++;
+        break;
+    }
+  }
+  if (!args.kind || !args.count) {
+    throw new Error('--kind and --count are required');
+  }
+  return {
+    kind: args.kind,
+    count: args.count,
+    capability: args.capability ?? 'translate',
+    out: args.out ?? `packages/perf/k6/fixtures/events-${args.kind}.json`,
+    seedKeys: args.seedKeys ?? Math.min(args.count, 256),
+  };
+}
+
+function buildContent(kind: number, capability: string, idx: number): string {
+  // kind 5100 (job request): plaintext input, broadcast variant.
+  if (kind >= 5000 && kind < 6000) {
+    return `perf-fixture job ${idx}: please ${capability} the following text`;
+  }
+  // kind 31990 (NIP-89 capability): handler info JSON.
+  if (kind === 31990) {
+    return JSON.stringify({
+      name: `perf-agent-${idx}`,
+      about: `synthetic perf-test agent ${idx}`,
+      picture: '',
+    });
+  }
+  return `perf-fixture event ${idx}`;
+}
+
+function buildTags(
+  kind: number,
+  capability: string,
+  idx: number,
+  providerPubkey: string,
+): string[][] {
+  // job request (NIP-90 family, elisym uses kind 5100)
+  if (kind >= 5000 && kind < 6000) {
+    return [
+      ['i', `perf input ${idx}`, 'text'],
+      ['t', capability],
+      ['t', 'elisym'],
+    ];
+  }
+  // NIP-89 capability announcement (kind 31990, parameterized replaceable)
+  if (kind === 31990) {
+    return [
+      ['d', `${capability}:${providerPubkey.slice(0, 8)}`],
+      ['k', '5100'],
+      ['t', capability],
+      ['t', 'elisym'],
+    ];
+  }
+  return [];
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Pool of synthetic keypairs to spread events across multiple authors,
+  // so the relay sees realistic fanout instead of a single hot author.
+  const keys = Array.from({ length: args.seedKeys }, () => {
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+    return { sk, pk };
+  });
+
+  const events: object[] = [];
+  for (let i = 0; i < args.count; i++) {
+    const key = keys[i % keys.length];
+    const event = finalizeEvent(
+      {
+        kind: args.kind,
+        created_at: Math.floor(Date.now() / 1000) - (args.count - i),
+        tags: buildTags(args.kind, args.capability, i, key.pk),
+        content: buildContent(args.kind, args.capability, i),
+      },
+      key.sk,
+    );
+    events.push(event);
+  }
+
+  const outPath = resolve(process.cwd(), args.out);
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, JSON.stringify(events));
+
+  process.stdout.write(
+    `wrote ${events.length} kind=${args.kind} events from ${keys.length} keypairs to ${args.out}\n`,
+  );
+}
+
+await main();

--- a/packages/perf/scripts/run.sh
+++ b/packages/perf/scripts/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Run a k6 scenario by name from packages/perf/k6/scenarios/<name>.js.
+#
+# Usage:
+#   bun run perf:run relay_publish
+#   bun run perf:run relay_publish -- -e TARGET_VUS=100 -e HOLD_S=120
+#
+# Pre-conditions:
+#   - `bun run perf:up` (strfry/prometheus/grafana running)
+#   - For relay_publish: a fixture in k6/fixtures/. The script auto-generates
+#     events-5100.json if missing.
+
+set -euo pipefail
+
+PERF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${PERF_DIR}/../.." && pwd)"
+
+SCENARIO="${1:-}"
+shift || true
+
+if [ -z "${SCENARIO}" ]; then
+  echo "usage: bun run perf:run <scenario> [-- k6 args]"
+  echo
+  echo "available scenarios:"
+  ls "${PERF_DIR}/k6/scenarios" | sed -E 's/\.js$//' | sed 's/^/  /'
+  exit 1
+fi
+
+SCENARIO_FILE="${PERF_DIR}/k6/scenarios/${SCENARIO}.js"
+if [ ! -f "${SCENARIO_FILE}" ]; then
+  echo "!! scenario not found: ${SCENARIO_FILE}"
+  exit 1
+fi
+
+if ! command -v k6 >/dev/null 2>&1; then
+  echo "!! k6 not on PATH. install: brew install k6  (mac) or see https://grafana.com/docs/k6/latest/set-up/install-k6/"
+  exit 1
+fi
+
+# Auto-generate fixture for relay_publish if missing.
+if [ "${SCENARIO}" = "relay_publish" ]; then
+  FIXTURE="${PERF_DIR}/k6/fixtures/events-5100.json"
+  if [ ! -f "${FIXTURE}" ]; then
+    echo "==> generating fixture ${FIXTURE}"
+    (cd "${REPO_ROOT}" && bun "${PERF_DIR}/scripts/generate-events.ts" \
+      --kind 5100 --count 5000 --seed-keys 256 \
+      --out "packages/perf/k6/fixtures/events-5100.json")
+  fi
+fi
+
+REPORTS_DIR="${PERF_DIR}/k6/reports"
+mkdir -p "${REPORTS_DIR}"
+
+RUN_ID="${SCENARIO}-$(date +%Y%m%d-%H%M%S)"
+
+echo "==> k6 run ${SCENARIO} (RUN_ID=${RUN_ID})"
+echo "    summary: ${REPORTS_DIR}/${SCENARIO}-${RUN_ID}.{json,html}"
+echo
+
+# k6 writes summary files to /reports inside its mental path; we simulate that
+# by passing the absolute reports dir as an env var the stats helper reads.
+# (See k6/lib/stats.js: it writes to /reports/<scenario>-<run>.{json,html}.)
+# We override that path here by writing summary in handleSummary using a
+# host-absolute path embedded via env.
+
+K6_OUT="experimental-prometheus-rw"
+K6_PROM_RW_URL="${K6_PROM_RW_URL:-http://localhost:9090/api/v1/write}"
+
+cd "${PERF_DIR}"
+
+K6_PROMETHEUS_RW_SERVER_URL="${K6_PROM_RW_URL}" \
+K6_PROMETHEUS_RW_TREND_STATS="p(50),p(95),p(99),min,max,avg" \
+SCENARIO="${SCENARIO}" \
+RUN_ID="${RUN_ID}" \
+REPORTS_DIR="${REPORTS_DIR}" \
+  k6 run \
+    --out "${K6_OUT}" \
+    --tag scenario="${SCENARIO}" \
+    --tag run_id="${RUN_ID}" \
+    "$@" \
+    "${SCENARIO_FILE}"
+
+echo
+echo "==> done. Reports:"
+ls -1 "${REPORTS_DIR}" | grep "${RUN_ID}" | sed 's/^/  /' || true
+echo
+echo "Grafana: http://localhost:3000"

--- a/packages/perf/scripts/stack-down.sh
+++ b/packages/perf/scripts/stack-down.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PERF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${PERF_DIR}/docker/docker-compose.yml"
+
+KEEP_VOLUMES="${KEEP_VOLUMES:-0}"
+
+if [ "${KEEP_VOLUMES}" = "1" ]; then
+  echo "==> docker compose down (keeping volumes)"
+  docker compose -f "${COMPOSE_FILE}" down --remove-orphans
+else
+  echo "==> docker compose down -v (wiping volumes)"
+  docker compose -f "${COMPOSE_FILE}" down --remove-orphans -v
+fi

--- a/packages/perf/scripts/stack-up.sh
+++ b/packages/perf/scripts/stack-up.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bring up the local perf stack: strfry + prometheus + grafana.
+# Phase 1 only; later phases extend docker-compose.yml with test-validator,
+# anchor-deploy (one-shot), bridge, and provider services.
+
+set -euo pipefail
+
+PERF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${PERF_DIR}/docker/docker-compose.yml"
+
+echo "==> docker compose up (file: ${COMPOSE_FILE})"
+docker compose -f "${COMPOSE_FILE}" up -d --remove-orphans
+
+echo "==> waiting for strfry (ws://localhost:7777)"
+for i in $(seq 1 30); do
+  if curl -fsS --max-time 1 -o /dev/null \
+       -H "Upgrade: websocket" \
+       -H "Connection: Upgrade" \
+       -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+       -H "Sec-WebSocket-Version: 13" \
+       "http://localhost:7777/" 2>/dev/null \
+     || curl -fsS --max-time 1 -o /dev/null "http://localhost:7777/" 2>/dev/null; then
+    echo "    strfry up after ${i}s"
+    break
+  fi
+  sleep 1
+  if [ "$i" = 30 ]; then
+    echo "!! strfry did not respond on :7777 after 30s; check 'docker compose logs strfry'"
+    exit 1
+  fi
+done
+
+echo "==> waiting for prometheus (http://localhost:9090)"
+for i in $(seq 1 30); do
+  if curl -fsS --max-time 1 -o /dev/null "http://localhost:9090/-/ready"; then
+    echo "    prometheus up after ${i}s"
+    break
+  fi
+  sleep 1
+  if [ "$i" = 30 ]; then
+    echo "!! prometheus not ready on :9090 after 30s"
+    exit 1
+  fi
+done
+
+echo "==> waiting for grafana (http://localhost:3000)"
+for i in $(seq 1 60); do
+  if curl -fsS --max-time 1 -o /dev/null "http://localhost:3000/api/health"; then
+    echo "    grafana up after ${i}s"
+    break
+  fi
+  sleep 1
+  if [ "$i" = 60 ]; then
+    echo "!! grafana not ready on :3000 after 60s"
+    exit 1
+  fi
+done
+
+echo
+echo "stack ready:"
+echo "  strfry      ws://localhost:7777"
+echo "  prometheus  http://localhost:9090"
+echo "  grafana     http://localhost:3000   (anonymous viewer)"
+echo
+echo "next: bun run perf:run relay_publish"

--- a/packages/perf/scripts/start-validator.sh
+++ b/packages/perf/scripts/start-validator.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Start solana-test-validator on the host with --reset and elisym-config
+# pre-loaded from target/deploy.
+#
+# Why on host (not in docker): the official Solana team does not maintain a
+# current docker image, and devs working on this repo already have the Solana
+# CLI installed (anchor depends on it). Keeping it on the host avoids a
+# brittle third-party image dependency.
+#
+# Usage:
+#   bun run perf:validator               # start in foreground; Ctrl+C to stop
+#   bun run perf:validator -- --reset    # extra flags forwarded
+set -euo pipefail
+
+if ! command -v solana-test-validator >/dev/null 2>&1; then
+  cat <<EOF
+!! solana-test-validator not found on PATH.
+   install Solana CLI: https://docs.solanalabs.com/cli/install
+   or via anza-xyz/agave release (current upstream).
+EOF
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PROGRAM_SO="${REPO_ROOT}/target/deploy/elisym_config.so"
+PROGRAM_ID="BrX1CRkSgvcjxBvc2bgc3QqgWjinusofDmeP7ZVxvwrE"
+
+EXTRA_ARGS=()
+if [ -f "${PROGRAM_SO}" ]; then
+  echo "==> loading elisym-config program from ${PROGRAM_SO}"
+  EXTRA_ARGS+=(--bpf-program "${PROGRAM_ID}" "${PROGRAM_SO}")
+else
+  echo "!! ${PROGRAM_SO} missing; run 'bun run program:build' first to load the program automatically."
+  echo "   continuing without elisym-config; protocol_config_cache scenario will fail until you load it."
+fi
+
+# Ledger lives in target/test-validator-ledger so it can be cleaned with the
+# rest of build artifacts via 'bun run clean' at the workspace level.
+LEDGER_DIR="${REPO_ROOT}/target/test-validator-ledger"
+mkdir -p "${LEDGER_DIR}"
+
+echo "==> solana-test-validator (ledger=${LEDGER_DIR})"
+exec solana-test-validator \
+  --reset \
+  --quiet \
+  --ledger "${LEDGER_DIR}" \
+  --rpc-port 8899 \
+  --bind-address 0.0.0.0 \
+  "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}" \
+  "$@"

--- a/packages/perf/skills/perf-translate/SKILL.md
+++ b/packages/perf/skills/perf-translate/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: perf-translate
+description: Free LLM-mode skill for capacity testing. Pair with MOCK_LLM=1 to avoid burning real credits.
+capabilities:
+  - translate
+price: 0
+mode: llm
+---
+
+You are a perf-test agent. Reply with a one-line acknowledgement that names the requested capability and the input length. Do not actually translate.
+
+This skill exists for `@elisym/perf` capacity tests. With `MOCK_LLM=1` set on the provider, the agent's LLM client is replaced by a synthetic responder that returns fixed-shape output with configurable latency. The skill itself is `mode: llm` and `price: 0` so it stays inside the free-LLM rate limiter without involving Solana.
+
+Copy this directory into `<your-perf-agent>/skills/perf-translate/` (e.g. `~/.elisym/perf-agent/skills/perf-translate/`) before running `provider_saturation`.

--- a/packages/perf/tsconfig.json
+++ b/packages/perf/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["bridge/src/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a local capacity-test stack for the elisym pipeline and captures
baseline numbers for the four headline product questions. Everything
runs on a laptop via docker compose + k6 + a thin HTTP bridge over
the SDK; no cloud infra, no shared resources.

## What this gives us

A reproducible answer to:

| Q | Question | Where it's measured |
|---|---|---|
| Q1 | How many agents can stay online before discovery degrades? | `agent_fleet_scale` |
| Q2 | How fast does an end user see search results on `/`? | `web_discovery_latency` |
| Q3 | How fast does `search_agents` return inside Claude / Cursor / Windsurf? | `mcp_discovery_latency` |
| Q4 | How many jobs/sec can one provider hold? | `provider_saturation` |

Plus diagnostic scenarios (`relay_publish`, `solana_rpc_burst`, `protocol_config_cache`, `discover_via_bridge`, `relay_subscribe_fanout`, `e2e_steady_state`).

## Baseline numbers (M3 Pro 18GB)

Recorded in `packages/perf/README.md` under **Observed numbers**:

- **relay_publish**: strfry 100% accept, OK round-trip p99 = 2 ms, peak ~1000 evt/s
- **agent_fleet_scale**: discover stays under 1 s p95 up to ~1000 agents; knee between 1000-2500; fleet=5000 → 5.5 s
- **web_discovery_latency** (fleet=5000, 1 VU): TTF p95 = 4.6 ms, complete p95 = 5.28 s, 100% success
- **mcp_discovery_latency**: p95 = 8.82 s, flat across fleet (enrichment-bound, not search itself)
- **provider_saturation** (MOCK_LLM): ~19 jobs/sec sustained, 100% ok; throughput gated by Nostr publish path, not provider compute

These set the "normal" curve so future regressions show up immediately.

## Architecture

- **`packages/perf/bridge/`** - Hono+Bun HTTP server wrapping `@elisym/sdk` so k6 (which can't run TS) can drive real SDK code paths. Endpoints: `/discover`, `/stream-discover`, `/fleet/resize`, `/mcp/*`, `/job/submit`, `/protocol-config`, `/metrics`.
- **`packages/perf/k6/scenarios/`** - 10 k6 scenarios mapped to the questions above.
- **`packages/perf/k6/lib/`** - shared env + nostr + summary helpers (incl. `createOkRouter` for high-throughput WS scenarios).
- **`packages/perf/docker/`** - strfry + Prometheus + Grafana stack with auto-provisioned datasource and 4 dashboards (k6, relay, provider, e2e).
- **`packages/perf/scripts/`** - `stack-up.sh` / `stack-down.sh` / `run.sh` / `start-validator.sh`.
- **`packages/perf/skills/perf-translate/`** - sample free-LLM skill for Q4 (pairs with `MOCK_LLM=1` to avoid burning real credits).

## CLI changes that this depends on (also in this PR)

- `@elisym/cli` gained an opt-in Prometheus exporter (`--metrics-port`) - serves `elisym_jobs_in_flight`, `elisym_jobs_pending`, `elisym_jobs_received_total`, `elisym_jobs_completed_total`, `elisym_job_duration_seconds` for the provider dashboard.
- `MOCK_LLM=1` env replaces the LLM client with a synthetic responder (`MOCK_LLM_JITTER_MS=N` for configurable latency). Strictly dev-only.

## How to run

Three terminals:

```bash
# T1
bun run perf:up                                  # strfry + prometheus + grafana

# T2
RELAYS=ws://localhost:7777 bun run perf:bridge   # SDK bridge

# T3
bun run perf:run relay_publish                   # any scenario name
```

Reports land in `packages/perf/k6/reports/<scenario>-<timestamp>.{html,json}`. Grafana on `http://localhost:3000` (anonymous viewer).

Walkthrough for Q1-Q4 in `packages/perf/README.md`.

## Scope

No production code paths changed - the CLI metrics exporter and MOCK_LLM are opt-in via flag/env. Everything else lives in `packages/perf/`.

## Test plan

- [x] `bun qa` green (build + tests + typecheck + lint + format + spell)
- [x] Full Q1-Q4 sweep run locally with the recorded numbers
- [x] Reviewer runs `bun run perf:up && bun run perf:run relay_publish` and gets ~1000 evt/s with 100% accept
- [x] Reviewer opens Grafana and sees populated panels on the "elisym - relay & discovery" dashboard