### PR TITLE
Harden security across SDK/MCP/CLI/app and bump releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   qa:
     name: QA
@@ -18,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,16 @@ on:
     types: [completed]
     branches: [main]
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-
 jobs:
   release:
     name: Release packages
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    permissions:
+      contents: write
+      id-token: write
 
     outputs:
       mcp_released: ${{ steps.publish.outputs.mcp_released }}
@@ -26,17 +25,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
 
       - name: Setup Node (npm >= 11.5.1 required for Trusted Publishing)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -102,6 +101,10 @@ jobs:
     needs: release
     if: needs.release.outputs.mcp_released == 'true' || needs.release.outputs.cli_released == 'true'
 
+    permissions:
+      contents: read
+      packages: write
+
     strategy:
       matrix:
         include:
@@ -121,11 +124,11 @@ jobs:
 
       - name: Checkout
         if: matrix.released == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Bun
         if: matrix.released == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.11'
 
@@ -137,11 +140,11 @@ jobs:
 
       - name: Setup Docker Buildx
         if: matrix.released == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to GHCR
         if: matrix.released == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -149,7 +152,7 @@ jobs:
 
       - name: Build and push
         if: matrix.released == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: packages/${{ matrix.package }}/Dockerfile
@@ -167,13 +170,32 @@ jobs:
     needs: release
     if: needs.release.outputs.mcp_released == 'true'
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.9
+          MCP_PUBLISHER_ASSET: mcp-publisher_linux_amd64.tar.gz
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
+          set -euo pipefail
+          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+          CHECKSUMS_FILE="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+
+          echo "Downloading ${MCP_PUBLISHER_ASSET} (${MCP_PUBLISHER_VERSION})..."
+          curl -fSL "${BASE_URL}/${MCP_PUBLISHER_ASSET}" -o "${MCP_PUBLISHER_ASSET}"
+          curl -fSL "${BASE_URL}/${CHECKSUMS_FILE}" -o "${CHECKSUMS_FILE}"
+
+          echo "Verifying SHA-256 checksum..."
+          grep " ${MCP_PUBLISHER_ASSET}\$" "${CHECKSUMS_FILE}" | sha256sum --check --strict -
+
+          echo "Checksum verified. Extracting..."
+          tar xzf "${MCP_PUBLISHER_ASSET}"
           sudo mv mcp-publisher /usr/local/bin/
 
       - name: Sync server.json version with package.json

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ CLAUDE.md
 .mcpregistry_github_token
 .mcpregistry_registry_token
 
+# deepsec security scanner (scaffold, local findings data, and .env.local with keys)
+.deepsec/
+
 # Anchor / Solana
 target/
 .anchor/

--- a/bun.lock
+++ b/bun.lock
@@ -14,9 +14,9 @@
     },
     "packages/app": {
       "name": "@elisym/app",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
-        "@elisym/sdk": "~0.20.0",
+        "@elisym/sdk": "~0.22.0",
         "@solana-program/memo": "~0.11.0",
         "@solana-program/token": "~0.5.0",
         "@solana/kit": "~6.8.0",
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@elisym/cli",
-      "version": "0.17.1",
+      "version": "0.20.0",
       "bin": {
         "elisym": "./dist/index.js",
       },
@@ -99,7 +99,7 @@
     },
     "packages/mcp": {
       "name": "@elisym/mcp",
-      "version": "0.11.1",
+      "version": "0.14.0",
       "bin": {
         "elisym-mcp": "./dist/index.js",
       },
@@ -126,7 +126,7 @@
     },
     "packages/sdk": {
       "name": "@elisym/sdk",
-      "version": "0.20.0",
+      "version": "0.23.0",
       "dependencies": {
         "yaml": "~2.8.3",
         "zod": "~3.25.0",
@@ -2732,6 +2732,8 @@
     "@codama/visitors-core/@codama/errors": ["@codama/errors@1.3.4", "", { "dependencies": { "@codama/node-types": "1.3.4", "chalk": "^5.6.0", "commander": "^14.0.0" }, "bin": { "errors": "bin/cli.cjs" } }, "sha512-gEbfWkf5J1klGlLbrg5zIMYTncYO6SCsLRxKbDRrE1TmxRqt3cUovQyPhccGcNh/e/GisauIGjbsZTJaFNgXuw=="],
 
     "@codama/visitors-core/@codama/nodes": ["@codama/nodes@1.3.4", "", { "dependencies": { "@codama/errors": "1.3.4", "@codama/node-types": "1.3.4" } }, "sha512-Q3eS/kMqiozZzlpY/otVfQQ9M3pRdCS0D1dlB3TyuHWBAJiAGPfjRT21KQ4M8xub6eTWJY7PwT7sykPqS/fQPg=="],
+
+    "@elisym/app/@elisym/sdk": ["@elisym/sdk@0.22.0", "", { "dependencies": { "yaml": "~2.8.3", "zod": "~3.25.0" }, "peerDependencies": { "@solana-program/memo": "~0.11.0", "@solana-program/system": "~0.12.0", "@solana-program/token": "~0.5.0", "@solana/kit": "~6.8.0", "decimal.js-light": "~2.5.0", "nostr-tools": "~2.23.0" } }, "sha512-IerDkh1QjTkOLzSvLrR8cgVukoGSMY2ClbECkgKz1jlohARPlpnQg3jjmGmd/oiEyEQKdGZQ1ryZm07gxf2UbA=="],
 
     "@elisym/sdk/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -108,3 +108,7 @@ wouter
 zeroize
 zeroized
 zod
+feff
+fsmonitor
+nosystem
+toctou

--- a/packages/app/app/components/StatsBar.tsx
+++ b/packages/app/app/components/StatsBar.tsx
@@ -6,7 +6,8 @@ import { useTweenedNumber } from '~/hooks/useTweenedNumber';
 import { UsdcIcon } from './UsdcIcon';
 
 const ON_CHAIN_TOOLTIP_TEXT =
-  'Live on-chain counter updated by the elisym client SDK alongside each payment.';
+  'Approximate. A self-reported on-chain counter bumped by clients alongside each ' +
+  'payment - not independently verified against actual token transfers.';
 
 const TOOLTIP_MAX_WIDTH = 240;
 const TOOLTIP_EDGE_MARGIN = 12;
@@ -286,6 +287,10 @@ export function StatsBar() {
           </div>
         </div>
       </div>
+
+      <p className="mt-10 text-center font-mono text-[10px] tracking-[0.08em] text-white/30 uppercase">
+        Approximate - self-reported, not verified
+      </p>
     </div>
   );
 }

--- a/packages/app/app/contexts/BuyContext.tsx
+++ b/packages/app/app/contexts/BuyContext.tsx
@@ -49,6 +49,7 @@ import { useJobHistory } from '~/hooks/useJobHistory';
 import { invalidateWalletBalances } from '~/hooks/useWalletBalances';
 import { track } from '~/lib/analytics';
 import { SDK_CLUSTER, SOLANA_RPC_URL } from '~/lib/cluster';
+import { formatCardPrice } from '~/lib/formatPrice';
 import { cacheSet } from '~/lib/localCache';
 
 const COMPUTE_UNIT_LIMIT = 200_000;
@@ -285,12 +286,39 @@ export function BuyProvider({ children }: { children: ReactNode }) {
               }
 
               try {
+                // Refuse to pay a card whose recipient we cannot verify: no
+                // advertised address, or a chain we don't settle on. Mirrors
+                // the MCP "Cannot verify payment recipient" guard - without a
+                // known recipient a provider could redirect funds anywhere.
+                const recipientAddress = card.payment?.address;
+                if (!recipientAddress) {
+                  throw new Error(
+                    'Cannot verify payment recipient - the provider published no payment ' +
+                      'address for this product. Refusing to proceed.',
+                  );
+                }
+                if (card.payment?.chain !== 'solana') {
+                  throw new Error(
+                    `Unsupported payment chain "${card.payment?.chain ?? 'unknown'}" - ` +
+                      'only Solana payments are supported. Refusing to proceed.',
+                  );
+                }
+
                 const protocolConfig = await getProtocolConfig(kitRpc, PROTOCOL_PROGRAM_ID);
+
+                // Bound the charge to the advertised price (subunits). Without
+                // this a malicious provider can inflate `paymentRequest.amount`
+                // after the customer committed (bait-and-switch). `job_price` is
+                // an integer subunit value; coerce via BigInt with no float math.
+                const advertisedPrice = card.payment?.job_price;
+                const maxAmountLamports =
+                  advertisedPrice === undefined ? undefined : BigInt(advertisedPrice);
 
                 const validationError = payment.validatePaymentRequest(
                   paymentRequestJson,
                   { feeBps: protocolConfig.feeBps, treasury: protocolConfig.treasury },
-                  card.payment?.address,
+                  recipientAddress,
+                  { maxAmountLamports },
                 );
                 if (validationError) {
                   throw new Error(validationError.message);
@@ -298,7 +326,21 @@ export function BuyProvider({ children }: { children: ReactNode }) {
 
                 const paymentRequest: PaymentRequestData = JSON.parse(paymentRequestJson);
 
-                toast.loading('Approve the transaction in your wallet...', { id: toastId });
+                // The `amount` tag on the payment-required feedback is what the
+                // provider claims to charge; `paymentRequest.amount` is what the
+                // signed request will actually move. They must agree, otherwise
+                // the feedback understated the real charge - abort.
+                if (amount !== undefined && amount !== paymentRequest.amount) {
+                  throw new Error(
+                    `Payment amount mismatch: feedback advertised ${amount} but the signed ` +
+                      `request charges ${paymentRequest.amount}. Refusing to proceed.`,
+                  );
+                }
+
+                const amountLabel = formatCardPrice(card.payment, paymentRequest.amount);
+                toast.loading(`Approve the ${amountLabel} payment in your wallet...`, {
+                  id: toastId,
+                });
 
                 const versionedTx = await buildVersionedPaymentTransaction(
                   paymentRequest,

--- a/packages/app/app/hooks/useStats.ts
+++ b/packages/app/app/hooks/useStats.ts
@@ -6,8 +6,15 @@ import { useLocalQuery } from './useLocalQuery';
 /**
  * Stats sourced from the on-chain `NetworkStats` PDA maintained by the
  * elisym-config program. One `getAccountInfo` per refetch - no signature
- * scans, no per-tx aggregation, no watermark heuristics. Source is monotonic
- * and authoritative by construction.
+ * scans, no per-tx aggregation, no watermark heuristics.
+ *
+ * IMPORTANT: this is a best-effort, self-reported counter, NOT an authoritative
+ * figure. The PDA is bumped by clients alongside payments; nothing verifies the
+ * increments against the real token transfers, so the counter can be inflated
+ * by a misbehaving or malicious client. Treat these numbers as approximate and
+ * label them as such in the UI. A verified figure would require aggregating
+ * actual on-chain transfers (see `aggregateNetworkStats`), which is far too slow
+ * for this view.
  */
 export interface UiNetworkStats {
   jobCount: number;

--- a/packages/app/app/lib/keyVault.ts
+++ b/packages/app/app/lib/keyVault.ts
@@ -116,15 +116,47 @@ export async function loadIdentities(): Promise<LoadIdentitiesResult> {
     return { identities: [], vaultLost: false };
   }
 
+  // Ask the browser to mark our origin storage as persistent so the CryptoKey
+  // in IndexedDB is less likely to be evicted under storage pressure (eviction
+  // is the main way the vault becomes unrecoverable). Best-effort and guarded -
+  // not all browsers expose `navigator.storage.persist`.
+  await requestPersistentStorage();
+
+  // Key acquisition and JSON parsing live OUTSIDE the decrypt try. A transient
+  // IndexedDB failure here (or a missing CryptoKey) must NOT evict the vault -
+  // we rethrow so the caller can retry on the next mount with the blob intact.
+  // Only a genuine decrypt failure (wrong key / corrupt ciphertext) relocates
+  // the blob below.
+  const blob: EncryptedBlob = JSON.parse(raw);
+  const key = await getOrCreateKey();
+
   try {
-    const blob: EncryptedBlob = JSON.parse(raw);
-    const key = await getOrCreateKey();
     const json = await decrypt(key, blob);
     return { identities: JSON.parse(json) as StoredIdentity[], vaultLost: false };
   } catch {
     localStorage.setItem(VAULT_LOST_KEY, raw);
     localStorage.removeItem(VAULT_KEY);
     return { identities: [], vaultLost: true };
+  }
+}
+
+/**
+ * Read the most recently relocated vault blob (raw, still-encrypted JSON) from
+ * the lost slot, or null if none exists. Lets a power user who restored the
+ * matching CryptoKey in IndexedDB recover the otherwise-orphaned blob - without
+ * this, the relocation in `loadIdentities` would be write-only.
+ */
+export function readLostVault(): string | null {
+  return localStorage.getItem(VAULT_LOST_KEY);
+}
+
+async function requestPersistentStorage(): Promise<void> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.storage?.persist) {
+      await navigator.storage.persist();
+    }
+  } catch {
+    // Persistence is advisory - ignore failures and proceed with the load.
   }
 }
 

--- a/packages/app/app/routes/Agent/Agent.tsx
+++ b/packages/app/app/routes/Agent/Agent.tsx
@@ -39,6 +39,11 @@ const THANKS_VISIBLE_MS = 3000;
 const THANKS_MOUNT_MS = 3700;
 const MAX_DISPLAY_NAME = 60;
 
+// A Nostr pubkey is a 32-byte ed25519 key rendered as 64 lowercase hex chars.
+// The route param is user-controlled, so a malformed value would otherwise
+// reach `nip19.npubEncode` and throw, crashing render. Route those to NotFound.
+const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/;
+
 const TABS = [
   {
     id: 'products' as const,
@@ -308,6 +313,7 @@ function useHydrateArtifacts(
 export default function AgentPage() {
   const params = useParams<{ pubkey: string }>();
   const pubkey = params.pubkey ?? '';
+  const isValidPubkey = HEX_PUBKEY_RE.test(pubkey);
   const [, setLocation] = useLocation();
   const search = useSearch();
 
@@ -458,7 +464,8 @@ export default function AgentPage() {
     }
   }, [search, pubkey, setLocation]);
 
-  const displayName = agentData?.name || (pubkey ? truncateKey(nip19.npubEncode(pubkey), 8) : '');
+  const displayName =
+    agentData?.name || (isValidPubkey ? truncateKey(nip19.npubEncode(pubkey), 8) : '');
 
   // Hoisted above early returns: useBuyForCard is a hook and must run on
   // every render, including the loading / not-found branches.
@@ -471,6 +478,12 @@ export default function AgentPage() {
     agentPicture: agentData?.picture,
     card: currentCard,
   });
+
+  // A malformed pubkey can never resolve to an agent and would crash the
+  // `nip19.npubEncode` paths below, so route it straight to NotFound.
+  if (!isValidPubkey) {
+    return <NotFound />;
+  }
 
   if (!agentData) {
     if (agentStatus === 'not-found') {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/cli",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "CLI agent runner for elisym - provider mode, skills, crash recovery",
   "keywords": [
     "ai-agents",
@@ -44,7 +44,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.22.0",
+    "@elisym/sdk": "~0.23.0",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/system": "~0.12.0",
     "@solana-program/token": "~0.5.0",

--- a/packages/cli/skills-examples/youtube-summary/scripts/summarize.py
+++ b/packages/cli/skills-examples/youtube-summary/scripts/summarize.py
@@ -12,17 +12,95 @@ Long transcripts are split into chunks for LLM processing.
 
 import argparse
 import hashlib
+import ipaddress
 import json
 import os
 import re
 import subprocess
 import sys
 import tempfile
+from urllib.parse import parse_qs, urlparse
 
 CHUNK_SIZE = 30_000  # ~7500 tokens, safe for rate limits
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 CACHE_DIR = os.path.join(SCRIPT_DIR, ".cache")
 COOKIES_FILE = os.path.join(os.path.dirname(SCRIPT_DIR), "cookies.txt")
+
+# Strict allowlist of YouTube hosts. Anything else (or any IP/metadata host) is rejected.
+ALLOWED_YOUTUBE_HOSTS = frozenset({
+    "www.youtube.com",
+    "youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+    "youtube-nocookie.com",
+    "www.youtube-nocookie.com",
+})
+# YouTube video ids are exactly 11 chars from this charset.
+VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+
+def _is_blocked_ip_host(hostname: str) -> bool:
+    """True if the hostname is an IP literal in a private/loopback/link-local/metadata range."""
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _host_is_allowed(hostname: str | None) -> bool:
+    """Exact-match allowlist check, plus a strict .youtube.com suffix (never a substring match)."""
+    if not hostname:
+        return False
+    host = hostname.lower()
+    if _is_blocked_ip_host(host):
+        return False
+    if host in ALLOWED_YOUTUBE_HOSTS:
+        return True
+    return host.endswith(".youtube.com")
+
+
+def extract_video_id(parsed) -> str | None:
+    """Extract the 11-char YouTube video id from a parsed URL, or None."""
+    host = (parsed.hostname or "").lower()
+    if host == "youtu.be" or host.endswith(".youtu.be"):
+        candidate = parsed.path.lstrip("/").split("/", 1)[0]
+        return candidate if VIDEO_ID_RE.match(candidate) else None
+    query_id = parse_qs(parsed.query).get("v", [None])[0]
+    if query_id and VIDEO_ID_RE.match(query_id):
+        return query_id
+    for prefix in ("/embed/", "/shorts/", "/v/"):
+        if parsed.path.startswith(prefix):
+            candidate = parsed.path[len(prefix):].split("/", 1)[0]
+            return candidate if VIDEO_ID_RE.match(candidate) else None
+    return None
+
+
+def canonicalize_youtube_url(url: str) -> str | None:
+    """Validate a YouTube URL and return a host-controlled canonical URL.
+
+    Prefers extracting the 11-char video id and rebuilding a canonical
+    https://www.youtube.com/watch?v=<id> URL so the attacker never controls
+    the host yt-dlp connects to. Falls back to the validated original URL when
+    no id can be extracted but the host passed strict validation. Returns None
+    if the URL fails scheme/host validation.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if not _host_is_allowed(parsed.hostname):
+        return None
+    video_id = extract_video_id(parsed)
+    if video_id:
+        return f"https://www.youtube.com/watch?v={video_id}"
+    return url
 
 
 def _cookies_args() -> list[str]:
@@ -234,13 +312,14 @@ def main():
     parser.add_argument("--chunk", type=int, default=None, help="Return specific chunk (0-indexed)")
     args = parser.parse_args()
 
-    if not re.search(r"(youtube\.com|youtu\.be)", args.url):
+    safe_url = canonicalize_youtube_url(args.url)
+    if safe_url is None:
         print("Error: not a valid YouTube URL", file=sys.stderr)
         sys.exit(1)
 
     # If requesting a specific chunk, read from cache
     if args.chunk is not None:
-        cached = load_cache(args.url)
+        cached = load_cache(safe_url)
         if not cached:
             print("Error: no cached transcript. Call without --chunk first.", file=sys.stderr)
             sys.exit(1)
@@ -259,7 +338,7 @@ def main():
 
     # Fetch transcript
     print("Fetching video info...", file=sys.stderr)
-    video_info = get_video_info(args.url)
+    video_info = get_video_info(safe_url)
     print(f"Video: {video_info['title']} ({video_info['duration'] // 60} min)", file=sys.stderr)
 
     if args.lang == "auto":
@@ -269,12 +348,12 @@ def main():
         lang = args.lang
 
     print(f"Fetching subtitles (lang={lang})...", file=sys.stderr)
-    transcript = fetch_subtitles(args.url, lang)
+    transcript = fetch_subtitles(safe_url, lang)
 
     if not transcript:
         print("No subtitles found, trying Whisper transcription...", file=sys.stderr)
         try:
-            transcript = transcribe_audio(args.url)
+            transcript = transcribe_audio(safe_url)
         except RuntimeError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
@@ -287,7 +366,7 @@ def main():
     print(f"Transcript: {len(transcript)} chars, {len(chunks)} chunk(s)", file=sys.stderr)
 
     # Cache for chunk retrieval
-    save_cache(args.url, {
+    save_cache(safe_url, {
         "title": video_info["title"],
         "channel": video_info["channel"],
         "duration_min": video_info["duration"] // 60,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -126,7 +126,9 @@ export async function cmdStart(
       console.log(`     Network  ${walletNetwork}`);
       console.log(`     Address  ${solanaAddress}`);
       if (process.env.SOLANA_RPC_URL) {
-        console.log(`     RPC      ${process.env.SOLANA_RPC_URL} (custom)`);
+        // FIX #10: a custom SOLANA_RPC_URL routinely carries an API key in its
+        // userinfo / query / path - redact before printing to the banner.
+        console.log(`     RPC      ${stripRpcSecrets(process.env.SOLANA_RPC_URL)} (custom)`);
       }
       console.log(`     SOL      ${formatSol(balance)} (${balance} lamports)`);
       console.log(`     USDC     ${formatAssetAmount(USDC_SOLANA_DEVNET, usdcBalance)}`);
@@ -729,16 +731,37 @@ export async function cmdStart(
 }
 
 /**
- * Return a log-safe representation of an RPC URL. Strips any userinfo
- * and query string so credentials embedded by third-party RPC
- * providers (Helius/Alchemy/QuickNode style `?api-key=...`) never land
- * in verbose stderr output.
+ * Public Solana RPC hosts whose URL path carries no secret. For these the
+ * path is safe to keep; every other host is treated as a third-party RPC
+ * (Helius/Alchemy/QuickNode) whose path may embed an API key.
+ */
+const PUBLIC_SOLANA_RPC_HOSTS = new Set([
+  'api.devnet.solana.com',
+  'api.mainnet-beta.solana.com',
+  'api.testnet.solana.com',
+]);
+
+/**
+ * Return a log-safe representation of an RPC URL. Strips any userinfo and
+ * query string so credentials embedded by third-party RPC providers
+ * (Helius/Alchemy/QuickNode style `?api-key=...`) never land in verbose
+ * stderr output or the startup banner.
+ *
+ * FIX #11: Alchemy/QuickNode embed the API key in the URL *path* (e.g.
+ * `https://solana-mainnet.g.alchemy.com/v2/<APIKEY>`), so stripping only the
+ * userinfo + query still leaks the key. For any host that is not a public
+ * `api.*.solana.com` endpoint we therefore redact the path too, returning just
+ * `protocol//host/***`. Public Solana hosts keep their (secret-free) path.
  */
 export function stripRpcSecrets(raw: string): string {
   try {
     const parsed = new URL(raw);
     parsed.username = '';
     parsed.password = '';
+    if (!PUBLIC_SOLANA_RPC_HOSTS.has(parsed.hostname)) {
+      // Third-party RPC: the path may carry an API key - drop it entirely.
+      return `${parsed.protocol}//${parsed.host}/***`;
+    }
     const marker = parsed.search.length > 0 ? '?***' : '';
     parsed.search = '';
     return `${parsed.toString()}${marker}`;

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -36,50 +36,6 @@ export function getRpcUrl(_network: string): string {
   return 'https://api.devnet.solana.com';
 }
 
-// --- SOL formatting (number only, no " SOL" suffix - use SDK's formatSol for display) ---
-
-export function formatLamports(lamports: number): string {
-  const whole = Math.floor(lamports / 1_000_000_000);
-  const frac = lamports % 1_000_000_000;
-  return `${whole}.${String(frac).padStart(9, '0')}`;
-}
-
-// --- SOL parsing ---
-
-export function parseSolToLamports(s: string): number | null {
-  const trimmed = s.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const dotPos = trimmed.indexOf('.');
-  if (dotPos === -1) {
-    const whole = parseInt(trimmed, 10);
-    if (isNaN(whole) || whole < 0) {
-      return null;
-    }
-    return whole * 1_000_000_000;
-  }
-
-  const wholePart = dotPos === 0 ? 0 : parseInt(trimmed.slice(0, dotPos), 10);
-  if (isNaN(wholePart)) {
-    return null;
-  }
-
-  const fracStr = trimmed.slice(dotPos + 1);
-  if (fracStr.length === 0 || fracStr.length > 9) {
-    return null;
-  }
-
-  const padded = fracStr.padEnd(9, '0');
-  const frac = parseInt(padded, 10);
-  if (isNaN(frac)) {
-    return null;
-  }
-
-  return wholePart * 1_000_000_000 + frac;
-}
-
 // --- USDC balance ---
 
 /**

--- a/packages/cli/src/ledger.ts
+++ b/packages/cli/src/ledger.ts
@@ -1,8 +1,14 @@
 /**
  * Job recovery ledger - persistent JSON storage for crash recovery.
  */
-import { readFileSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync } from 'node:fs';
 import { dirname } from 'node:path';
+
+// Ledger files hold customer-confidential job content (inputs, results). Lock
+// the directory and files down to owner-only, matching the rest of the agent
+// store, so other local users cannot read them.
+const LEDGER_DIR_MODE = 0o700;
+const LEDGER_FILE_MODE = 0o600;
 
 export type LedgerStatus = 'paid' | 'executed' | 'delivered' | 'failed';
 
@@ -55,7 +61,11 @@ export class JobLedger {
       if (e?.code !== 'ENOENT') {
         console.warn(`  ! Ledger load warning: ${e?.message ?? 'unknown error'}`);
         try {
-          renameSync(this.path, this.path + '.corrupt.' + Date.now());
+          const backupPath = this.path + '.corrupt.' + Date.now();
+          renameSync(this.path, backupPath);
+          // The backup inherits the original (possibly world-readable) perms,
+          // so tighten it to owner-only - it still holds job content.
+          chmodSync(backupPath, LEDGER_FILE_MODE);
         } catch {
           /* best effort backup */
         }
@@ -65,11 +75,14 @@ export class JobLedger {
 
   flush(): void {
     const dir = dirname(this.path);
-    mkdirSync(dir, { recursive: true });
+    mkdirSync(dir, { recursive: true, mode: LEDGER_DIR_MODE });
     const obj = Object.fromEntries(this.entries);
     const tmp = this.path + '.tmp';
-    writeFileSync(tmp, JSON.stringify(obj, null, 2));
+    writeFileSync(tmp, JSON.stringify(obj, null, 2), { mode: LEDGER_FILE_MODE });
     renameSync(tmp, this.path);
+    // writeFileSync's `mode` is masked by the process umask, so an explicit
+    // chmod after the rename guarantees owner-only perms regardless of umask.
+    chmodSync(this.path, LEDGER_FILE_MODE);
   }
 
   recordPaid(entry: Omit<LedgerEntry, 'status' | 'retry_count'>): void {

--- a/packages/cli/src/llm/providers/http.ts
+++ b/packages/cli/src/llm/providers/http.ts
@@ -5,6 +5,10 @@
  * provider does not re-derive timeout/abort plumbing.
  */
 
+// `ReadableStream` is a runtime global in Bun/Node but is not declared by this
+// package's TS lib; import the typed constructor from node:stream/web.
+import { ReadableStream } from 'node:stream/web';
+
 // Per-HTTP-request timeout for LLM calls. This is a backstop against a hung
 // socket, not the job's execution ceiling - the per-job AbortSignal (driven by
 // the skill/agent execution budget) is wired into every fetch and is the real
@@ -69,12 +73,76 @@ export async function fetchWithTimeout(
   const timer = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
   const onAbort = (): void => controller.abort();
   signal?.addEventListener('abort', onAbort, { once: true });
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
+  let toreDown = false;
+  const teardown = (): void => {
+    if (toreDown) {
+      return;
+    }
+    toreDown = true;
     clearTimeout(timer);
     signal?.removeEventListener('abort', onAbort);
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    // Headers phase failed or was aborted - nothing more to cover.
+    teardown();
+    throw error;
   }
+
+  // FIX #31: the timeout/abort wiring (`timer` + parent `signal`) must stay
+  // armed across the body read, not be torn down the moment `fetch()` resolves
+  // the headers. Callers consume the body right after this returns
+  // (`response.json()` / `.text()`), which still streams over the same socket;
+  // tearing the wiring down in a `finally` here left that phase unbounded.
+  //
+  // The returned `Response`'s body methods are read-only, so instead of
+  // patching them we tap the underlying body stream and rebuild the `Response`
+  // over a stream we control. Teardown runs when the body is fully read
+  // (reader reports `done`), when the read errors, or when the consumer
+  // cancels the body (`response.body?.cancel()`) - covering every body-phase
+  // exit. `controller.signal` still backs the original stream, so a stall
+  // mid-body trips `timer`, which aborts the read and rejects the pull. The
+  // new `Response` preserves status / statusText / headers and all
+  // body-consuming methods, so there are no call-site changes. A 204/no-body
+  // response has nothing to wait on, so teardown is immediate.
+  const body = response.body;
+  // No readable stream to bound (204/no-body, or a non-stream body e.g. in tests):
+  // nothing to keep the wiring armed for, so tear down and return as-is.
+  if (!body || typeof body.getReader !== 'function') {
+    teardown();
+    return response;
+  }
+
+  const reader = body.getReader();
+  const tappedStream = new ReadableStream<Uint8Array>({
+    async pull(streamController) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          teardown();
+          streamController.close();
+          return;
+        }
+        streamController.enqueue(value);
+      } catch (error) {
+        teardown();
+        streamController.error(error);
+      }
+    },
+    cancel(reason) {
+      teardown();
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(tappedStream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 export async function fetchWithRetry(

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -19,6 +19,7 @@ import {
   freeLlmCustomerKey,
   LlmHealthError,
   ScriptBillingExhaustedError,
+  ScriptExecutionError,
   type FreeLlmLimiterSet,
   type LlmHealthMonitor,
 } from '@elisym/sdk/llm-health';
@@ -179,6 +180,37 @@ class ExecutionBudgetExceededError extends Error {
     super(`Execution exceeded budget (${Math.round(budgetMs / 1000)}s)`);
     this.name = 'ExecutionBudgetExceededError';
   }
+}
+
+// Allowlist of safe, informative messages the runtime itself produces and may
+// forward verbatim to a remote customer. Everything not matched here (raw script
+// stderr, provider internals, unexpected errors) collapses to a fixed generic
+// string; full detail is kept in the operator log only.
+const CUSTOMER_SAFE_MESSAGE_PREFIXES = ['Input too long', 'No skill matched', 'Payment timeout'];
+
+/**
+ * Resolve the error message that is safe to send to a remote customer. Inverts
+ * the old leaky denylist (forward-unless-contains-"API") into an allowlist so
+ * raw subprocess output or provider error bodies can never leak.
+ */
+function customerSafeMessage(error: unknown): string {
+  if (error instanceof AgentUnavailableError || error instanceof ExecutionBudgetExceededError) {
+    return error.message;
+  }
+  if (error instanceof ScriptExecutionError) {
+    // Generic summary only - `error.detail` (raw stderr/stdout) stays operator-side.
+    return error.message;
+  }
+  if (error instanceof ScriptBillingExhaustedError) {
+    return AGENT_UNAVAILABLE_MESSAGE;
+  }
+  if (
+    error instanceof Error &&
+    CUSTOMER_SAFE_MESSAGE_PREFIXES.some((prefix) => error.message.startsWith(prefix))
+  ) {
+    return error.message;
+  }
+  return 'Internal processing error';
 }
 
 function bodyLooksLikeBilling(body: string): boolean {
@@ -434,7 +466,16 @@ export class AgentRuntime {
     // self-flapping for chronic ones (acceptable - operator log makes
     // this visible).
     if (skill.mode !== 'llm') {
-      const message = err instanceof Error ? err.message : String(err);
+      // Use the raw stderr/stdout (`detail`) for billing/invalid marker scanning
+      // and the operator log - the generic `.message` no longer carries it.
+      let message: string;
+      if (err instanceof ScriptExecutionError) {
+        message = err.detail;
+      } else if (err instanceof Error) {
+        message = err.message;
+      } else {
+        message = String(err);
+      }
       const provider = skill.llmOverride?.provider;
       const model = skill.llmOverride?.model;
       if (!provider || !model) {
@@ -713,22 +754,18 @@ export class AgentRuntime {
           `[${job.jobId.slice(0, 8)}] Keeping status=paid; recovery will re-execute when LLM pair recovers (24h cutoff).`,
         );
       }
-      this.callbacks.onJobError?.(job.jobId, e.message);
+      // Operator log keeps the full detail (including raw script stderr from a
+      // ScriptExecutionError); the customer only ever receives an allowlisted,
+      // generic message via `customerSafeMessage`.
+      const operatorMessage =
+        e instanceof ScriptExecutionError
+          ? `${e.message}: ${e.detail}`
+          : (e.message ?? 'Unknown error');
+      this.callbacks.onJobError?.(job.jobId, operatorMessage);
 
-      // W8: Sanitize error messages before sending to customer.
-      // `AgentUnavailableError` is the runtime's own marker for a
-      // billing/invalid health flip and carries the canonical
-      // customer-facing string - pass it through verbatim. Anything
-      // mentioning "API" otherwise is a leaky provider error and gets
-      // masked.
-      let safeMessage: string;
-      if (e instanceof AgentUnavailableError) {
-        safeMessage = e.message;
-      } else if (e.message?.includes('API')) {
-        safeMessage = 'Internal processing error';
-      } else {
-        safeMessage = e.message ?? 'Unknown error';
-      }
+      // W8: only forward known-safe messages to the customer; everything else is
+      // masked to a fixed generic string so subprocess/provider internals never leak.
+      const safeMessage = customerSafeMessage(e);
       await this.transport
         .sendFeedback(job, { type: 'error', message: safeMessage })
         .catch(() => {});

--- a/packages/cli/tests/helpers.test.ts
+++ b/packages/cli/tests/helpers.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  getRpcUrl,
-  parseSolToLamports,
-  formatLamports,
-  validateJobPrice,
-  RENT_EXEMPT_MINIMUM,
-} from '../src/helpers.js';
+import { getRpcUrl, validateJobPrice, RENT_EXEMPT_MINIMUM } from '../src/helpers.js';
 
 describe('getRpcUrl', () => {
   it('returns devnet URL for devnet', () => {
@@ -30,78 +24,6 @@ describe('getRpcUrl', () => {
         process.env.SOLANA_RPC_URL = prev;
       }
     }
-  });
-});
-
-describe('formatLamports', () => {
-  it('formats zero', () => {
-    expect(formatLamports(0)).toBe('0.000000000');
-  });
-
-  it('formats 1 SOL', () => {
-    expect(formatLamports(1_000_000_000)).toBe('1.000000000');
-  });
-
-  it('formats fractional SOL', () => {
-    expect(formatLamports(10_000_000)).toBe('0.010000000');
-  });
-
-  it('formats large amounts', () => {
-    expect(formatLamports(100_000_000_000)).toBe('100.000000000');
-  });
-
-  it('does not include SOL suffix', () => {
-    expect(formatLamports(1_000_000_000)).not.toContain('SOL');
-  });
-});
-
-describe('parseSolToLamports', () => {
-  it('parses whole number', () => {
-    expect(parseSolToLamports('1')).toBe(1_000_000_000);
-  });
-
-  it('parses zero', () => {
-    expect(parseSolToLamports('0')).toBe(0);
-  });
-
-  it('parses decimal', () => {
-    expect(parseSolToLamports('0.01')).toBe(10_000_000);
-  });
-
-  it('parses full precision', () => {
-    expect(parseSolToLamports('1.000000001')).toBe(1_000_000_001);
-  });
-
-  it('parses leading dot', () => {
-    expect(parseSolToLamports('.5')).toBe(500_000_000);
-  });
-
-  it('trims whitespace', () => {
-    expect(parseSolToLamports('  1  ')).toBe(1_000_000_000);
-  });
-
-  it('returns null for empty string', () => {
-    expect(parseSolToLamports('')).toBeNull();
-  });
-
-  it('returns null for whitespace only', () => {
-    expect(parseSolToLamports('   ')).toBeNull();
-  });
-
-  it('returns null for negative', () => {
-    expect(parseSolToLamports('-1')).toBeNull();
-  });
-
-  it('returns null for too many decimals', () => {
-    expect(parseSolToLamports('0.0000000001')).toBeNull();
-  });
-
-  it('returns null for non-numeric', () => {
-    expect(parseSolToLamports('abc')).toBeNull();
-  });
-
-  it('returns null for trailing dot with no decimals', () => {
-    expect(parseSolToLamports('1.')).toBeNull();
   });
 });
 

--- a/packages/cli/tests/rpc-url-scrub.test.ts
+++ b/packages/cli/tests/rpc-url-scrub.test.ts
@@ -9,14 +9,21 @@ describe('stripRpcSecrets', () => {
   it('masks an embedded query-string API key (Helius style)', () => {
     const scrubbed = stripRpcSecrets('https://rpc.helius.xyz?api-key=hunter2');
     expect(scrubbed).not.toContain('hunter2');
-    expect(scrubbed).toContain('?***');
+    // Third-party host: path + query dropped, host-only with a marker.
+    expect(scrubbed).toBe('https://rpc.helius.xyz/***');
   });
 
   it('masks multiple query params atomically', () => {
     const scrubbed = stripRpcSecrets('https://api.example/rpc?token=XXX&network=mainnet');
     expect(scrubbed).not.toContain('XXX');
     expect(scrubbed).not.toContain('mainnet');
-    expect(scrubbed).toContain('?***');
+    expect(scrubbed).toBe('https://api.example/***');
+  });
+
+  it('strips a path-embedded API key (Alchemy/QuickNode style)', () => {
+    const scrubbed = stripRpcSecrets('https://solana-mainnet.g.alchemy.com/v2/SECRETKEY123');
+    expect(scrubbed).not.toContain('SECRETKEY123');
+    expect(scrubbed).toBe('https://solana-mainnet.g.alchemy.com/***');
   });
 
   it('strips userinfo credentials (http basic auth style)', () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for elisym - AI agent discovery, jobs, and payments",
   "keywords": [
     "ai-agents",
@@ -56,7 +56,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.22.0",
+    "@elisym/sdk": "~0.23.0",
     "@modelcontextprotocol/sdk": "~1.28.0",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/system": "~0.12.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "websiteUrl": "https://www.elisym.network",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@elisym/mcp",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -367,13 +367,14 @@ async function setSessionLimit(
   mint: string | undefined,
 ): Promise<void> {
   const asset = resolveAssetOrThrow(chain, token, mint);
-  // Validate the amount format strictly — uses the same BigInt integer math
-  // that enforcement applies at runtime.
-  parseAssetAmount(asset, amount);
-  const parsedAmount = Number(amount);
-  if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
-    throw new Error(`amount "${amount}" must be a positive decimal`);
-  }
+  // Validate the amount format strictly using the same integer math that
+  // enforcement applies at runtime. parseAssetAmount rejects non-positive,
+  // scientific-notation, and otherwise malformed inputs, so it is the sole
+  // validation gate - we then store the trimmed decimal STRING as-is (the
+  // schema field is a positive-decimal string; routing money through Number
+  // would lose precision and risk scientific-notation round-trips).
+  const trimmedAmount = amount.trim();
+  parseAssetAmount(asset, trimmedAmount);
 
   const path = globalConfigPath();
   const cfg = await loadGlobalConfig(path);
@@ -388,7 +389,7 @@ async function setSessionLimit(
     chain: asset.chain,
     token: asset.token,
     mint: asset.mint,
-    amount: parsedAmount,
+    amount: trimmedAmount,
   };
   if (idx >= 0) {
     entries[idx] = newEntry;
@@ -397,7 +398,7 @@ async function setSessionLimit(
   }
   await writeGlobalConfig(path, { session_spend_limits: entries });
   console.log(
-    `Session spend limit set to ${amount} ${asset.symbol} (process-wide). ` +
+    `Session spend limit set to ${trimmedAmount} ${asset.symbol} (process-wide). ` +
       `Restart the MCP server to apply.`,
   );
 }

--- a/packages/mcp/src/install.ts
+++ b/packages/mcp/src/install.ts
@@ -75,6 +75,12 @@ export async function safeRewriteJson(
         `Close the MCP client and re-run.`,
     );
   }
+  // Known, ACCEPTED residual TOCTOU: a concurrent writer could still land
+  // between this recheck and the rename(2) below. The recheck converts the
+  // common case (client rewrote the file while we were mutating it) into a
+  // visible "modified during update" error instead of silent data loss; a
+  // complete fix would require advisory file locking (proper-lockfile / flock),
+  // a dependency we intentionally do not add here.
   await writeJsonAtomic(path, newConfig);
 }
 

--- a/packages/mcp/src/job-input.ts
+++ b/packages/mcp/src/job-input.ts
@@ -7,7 +7,7 @@
  */
 import { execFile } from 'node:child_process';
 import { stat, readFile } from 'node:fs/promises';
-import { isAbsolute, resolve as resolvePath } from 'node:path';
+import { isAbsolute, relative, resolve as resolvePath } from 'node:path';
 import { promisify } from 'node:util';
 import { MAX_INPUT_LEN } from './utils.js';
 
@@ -15,6 +15,26 @@ const execFileP = promisify(execFile);
 
 /** Hard ceiling on input file paths so we never call `stat` on a multi-MB string. */
 export const MAX_INPUT_PATH_LEN = 4096;
+
+/**
+ * Files that are never a legitimate job input and are the prime exfiltration
+ * target (threat #1: secret-key / API-key theft). Matched on the resolved path;
+ * always refused regardless of the allow-outside-cwd opt-in.
+ */
+const SENSITIVE_NAME_RE =
+  /(^|[/\\])(\.secrets\.json|\.env(\..+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*-keypair\.json|.*\.pem|.*\.key)$/i;
+const SENSITIVE_DIR_SEGMENTS = new Set(['.elisym', '.ssh', '.aws', '.gnupg']);
+
+function isSensitiveInputPath(absPath: string): boolean {
+  if (SENSITIVE_NAME_RE.test(absPath)) {
+    return true;
+  }
+  if (absPath === '/proc' || absPath.startsWith('/proc/')) {
+    return true;
+  }
+  const segments = absPath.split(/[/\\]+/);
+  return segments.some((segment) => SENSITIVE_DIR_SEGMENTS.has(segment.toLowerCase()));
+}
 
 /** Wall-clock cap on each `git` invocation. Diffs of in-tree work are sub-second. */
 const GIT_TIMEOUT_MS = 30_000;
@@ -27,17 +47,73 @@ const GIT_TIMEOUT_MS = 30_000;
 const GIT_MAX_BUFFER = MAX_INPUT_LEN * 2;
 
 /**
+ * Config overrides injected before every git subcommand. git honors a repo-local
+ * `.git/config` for the work tree it runs in, and `diff.external` / `core.fsmonitor`
+ * / hooks are arbitrary-command-execution vectors - so reviewing an untrusted repo
+ * could run attacker code with the MCP server's privileges (in-memory secret keys).
+ * These `-c` overrides neutralize those keys; `GIT_CONFIG_NOSYSTEM=1` (set in env)
+ * additionally ignores /etc/gitconfig. `safe.directory` does NOT cover this - it only
+ * blocks differently-owned repos, not a user-owned malicious clone/tarball.
+ */
+const GIT_SAFETY_ARGS = [
+  '-c',
+  'core.fsmonitor=',
+  '-c',
+  'diff.external=',
+  '-c',
+  'core.hooksPath=/dev/null',
+];
+
+/** Strict ref validation for the user-supplied diff `base` (no leading `-`, no `..` ranges). */
+function isValidGitRef(ref: string): boolean {
+  if (ref.length === 0 || ref.length > 256) {
+    return false;
+  }
+  if (ref.startsWith('-') || ref.includes('..')) {
+    return false;
+  }
+  return /^[A-Za-z0-9._/@~^-]+$/.test(ref);
+}
+
+/**
  * Read a job input from a regular file on disk, with size and decoding guards.
  * Relative paths resolve against `process.cwd()` (the MCP server's working dir,
  * which for stdio clients is the dir the client was launched from).
  *
  * Throws a user-facing Error on missing file, non-file path, or oversize content.
  */
-export async function readJobInputFile(inputPath: string): Promise<string> {
+export async function readJobInputFile(
+  inputPath: string,
+  options?: { allowOutsideCwd?: boolean },
+): Promise<string> {
   if (inputPath.length > MAX_INPUT_PATH_LEN) {
     throw new Error(`input_path too long: ${inputPath.length} chars (max ${MAX_INPUT_PATH_LEN}).`);
   }
-  const absPath = isAbsolute(inputPath) ? inputPath : resolvePath(process.cwd(), inputPath);
+  const cwd = resolvePath(process.cwd());
+  const absPath = isAbsolute(inputPath) ? resolvePath(inputPath) : resolvePath(cwd, inputPath);
+
+  // Always refuse known-sensitive files (secret keys, .env, SSH/keypair, ~/.elisym,
+  // /proc). This forwards the file content to a remote provider before any payment
+  // and is invisible in the transcript, so an injected path must never reach a secret.
+  if (isSensitiveInputPath(absPath)) {
+    throw new Error(
+      `Refusing to read a sensitive file as job input: ${absPath}. ` +
+        `Secret keys, .env, SSH/keypair files, ~/.elisym and /proc are blocked.`,
+    );
+  }
+  // By default confine reads to the server's working-directory subtree. Reading
+  // elsewhere requires the explicit allow_outside_cwd opt-in (still subject to the
+  // sensitive-file block above).
+  if (!options?.allowOutsideCwd) {
+    const rel = relative(cwd, absPath);
+    const insideCwd = rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+    if (!insideCwd) {
+      throw new Error(
+        `input_path "${absPath}" resolves outside the working directory (${cwd}). ` +
+          `Move the file under the working directory or pass allow_outside_cwd: true.`,
+      );
+    }
+  }
 
   let stats;
   try {
@@ -78,11 +154,11 @@ export async function readJobInputFile(inputPath: string): Promise<string> {
  */
 async function execGit(repoPath: string, args: string[]): Promise<string> {
   try {
-    const { stdout } = await execFileP('git', args, {
+    const { stdout } = await execFileP('git', [...GIT_SAFETY_ARGS, ...args], {
       cwd: repoPath,
       timeout: GIT_TIMEOUT_MS,
       maxBuffer: GIT_MAX_BUFFER,
-      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_CONFIG_NOSYSTEM: '1' },
     });
     return stdout;
   } catch (e) {
@@ -169,18 +245,26 @@ export async function computeGitDiff(repoPath: string, base?: string): Promise<G
   let args: string[];
   let describedRange: string;
   if (base) {
-    args = ['diff', `${base}...HEAD`];
+    // Validate the user-supplied ref and place it after `--end-of-options` so a
+    // value like `--output=/etc/passwd` can never be parsed as a git flag (#14).
+    if (!isValidGitRef(base)) {
+      throw new Error(
+        `Invalid "base": ${base}. Use a branch/tag/commit ref (letters, digits, ` +
+          `". _ / @ ~ ^ -", no leading "-", no "..").`,
+      );
+    }
+    args = ['diff', '--no-ext-diff', '--end-of-options', `${base}...HEAD`];
     describedRange = `${base}...HEAD`;
   } else if (await isDirty(absRepo)) {
-    args = ['diff', 'HEAD'];
+    args = ['diff', '--no-ext-diff', 'HEAD'];
     describedRange = 'HEAD (working tree, uncommitted changes)';
   } else {
     const detected = await detectDefaultBase(absRepo);
     if (detected) {
-      args = ['diff', `${detected}...HEAD`];
+      args = ['diff', '--no-ext-diff', '--end-of-options', `${detected}...HEAD`];
       describedRange = `${detected}...HEAD`;
     } else {
-      args = ['diff', 'HEAD'];
+      args = ['diff', '--no-ext-diff', 'HEAD'];
       describedRange = 'HEAD (no main/master detected)';
     }
   }

--- a/packages/mcp/src/sanitize.ts
+++ b/packages/mcp/src/sanitize.ts
@@ -150,8 +150,11 @@ function stripDangerousUnicode(text: string): string {
   // C0 controls except \n and \t, C1 controls, bidi overrides, bidi isolates,
   // zero-width chars, tag chars, replacement char
   return text.replace(
+    // C0 (minus \n,\t) + C1 controls; bidi marks/overrides/isolates (061C, 200E-200F,
+    // 202A-202E, 2066-2069); zero-width + word-joiner + invisible-operator format chars
+    // (200B-200D, 2060-2064, 180E, FEFF); tag chars; replacement char.
     // eslint-disable-next-line no-control-regex
-    /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\u202A-\u202E\u2066-\u2069\u200B-\u200D\uFEFF\uFFFD]|[\uDB40][\uDC01-\uDC7F]/g,
+    /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\u061C\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF\uFFFD]|[\uDB40][\uDC01-\uDC7F]/g,
     '',
   );
 }
@@ -181,10 +184,20 @@ function detectInjections(text: string, includeNoisy: boolean): boolean {
   if (normalized.length <= INJECTION_SCAN_BUDGET) {
     return patterns.some((p) => p.pattern.test(normalized));
   }
-  // Scan both head and tail so an attacker cannot pad 8k of benign text before the payload.
-  const head = normalized.slice(0, INJECTION_SCAN_BUDGET);
-  const tail = normalized.slice(-INJECTION_SCAN_BUDGET);
-  return patterns.some((p) => p.pattern.test(head) || p.pattern.test(tail));
+  // Scan the FULL text in bounded, overlapping windows. Head/tail-only scanning
+  // let an attacker bury the payload in the middle (between the first and last 8k);
+  // windowing keeps each regex run bounded (no pathological backtracking on huge
+  // input) while covering everything. The overlap catches a match straddling a
+  // window boundary (injection patterns match well within OVERLAP chars).
+  const OVERLAP = 256;
+  const step = INJECTION_SCAN_BUDGET - OVERLAP;
+  for (let start = 0; start < normalized.length; start += step) {
+    const window = normalized.slice(start, start + INJECTION_SCAN_BUDGET);
+    if (patterns.some((p) => p.pattern.test(window))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -214,8 +227,15 @@ export function isLikelyBase64(s: string): boolean {
   if (s.length < 64) {
     return false;
   }
-  const base64Chars = s.replace(/[A-Za-z0-9+/=\s]/g, '');
-  return base64Chars.length / s.length < 0.05;
+  // Real base64 contains no internal whitespace. Allowing \s previously let plain
+  // prose ("ignore all previous instructions ...") - only letters, digits, spaces -
+  // score as base64 and skip the injection scan. Reject any whitespace and require a
+  // very high base64-alphabet ratio so only genuine encoded blobs are treated as binary.
+  if (/\s/.test(s)) {
+    return false;
+  }
+  const nonBase64Chars = s.replace(/[A-Za-z0-9+/=]/g, '');
+  return nonBase64Chars.length / s.length < 0.02;
 }
 
 export interface SanitizeResult {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -62,6 +62,20 @@ if (toolMap.size !== allTools.length) {
 export const registeredTools: readonly ToolDefinition[] = allTools;
 
 /**
+ * Scrub secret/key shapes from a string before it is returned to the LLM:
+ * Nostr `nsec` bech32 keys, Anthropic/OpenAI `sk-` API keys, 64-char hex
+ * (private-key/seed shape), and long base58 (secret-key length). Public 32-44
+ * char base58 addresses are intentionally left alone.
+ */
+function redactSecrets(text: string): string {
+  return text
+    .replace(/\bnsec1[02-9ac-hj-np-z]{20,}\b/gi, '[REDACTED]')
+    .replace(/\bsk-(?:ant-)?[A-Za-z0-9_-]{16,}\b/g, '[REDACTED]')
+    .replace(/\b[0-9a-fA-F]{64}\b/g, '[REDACTED]')
+    .replace(/\b[1-9A-HJ-NP-Za-km-z]{80,}\b/g, '[REDACTED]');
+}
+
+/**
  * turn any thrown value into a short, LLM-friendly message. Full stack and
  * original error go to stderr for operator debugging; the LLM only sees a one-line
  * summary so we don't leak internal paths / stack traces into the model context.
@@ -90,7 +104,10 @@ export function safeError(context: string, e: unknown): CallToolResult {
   }
 
   return {
-    content: [{ type: 'text' as const, text: msg }],
+    // pino redact does not cover error-message string contents, so scrub key/secret
+    // shapes from the LLM-facing message itself (e.g. a JSON parse error that echoes
+    // a secrets file, or an RPC error embedding a key).
+    content: [{ type: 'text' as const, text: redactSecrets(msg) }],
     isError: true,
   };
 }
@@ -219,7 +236,8 @@ export async function startServer(ctx: AgentContext): Promise<void> {
       const { value: balanceLamports } = await rpc
         .getBalance(address(agent.solanaKeypair.publicKey))
         .send();
-      const balance = Number(balanceLamports);
+      // balanceLamports is a bigint from the RPC - keep it bigint (no Number
+      // round-trip, which would lose precision on large balances).
       return {
         contents: [
           {
@@ -229,8 +247,8 @@ export async function startServer(ctx: AgentContext): Promise<void> {
               {
                 address: agent.solanaKeypair.publicKey,
                 network: agent.network,
-                balance_lamports: balance,
-                balance_sol: formatSolNumeric(BigInt(balance)),
+                balance_lamports: balanceLamports.toString(),
+                balance_sol: formatSolNumeric(balanceLamports),
                 chain: 'solana',
               },
               null,

--- a/packages/mcp/src/session-limits.ts
+++ b/packages/mcp/src/session-limits.ts
@@ -70,7 +70,11 @@ export async function buildEffectiveLimits(): Promise<Map<string, bigint>> {
       throw new Error(`Duplicate session_spend_limit entry in ${globalConfigPath()}: ${key}`);
     }
     seen.add(key);
-    map.set(key, parseAssetAmount(asset, entry.amount.toString()));
+    // `entry.amount` is already a positive-decimal string (the global-schema
+    // field transforms string|number into a string), so it feeds straight into
+    // parseAssetAmount's integer math - no Number() coercion, no scientific-
+    // notation round-trip.
+    map.set(key, parseAssetAmount(asset, entry.amount));
   }
   return map;
 }

--- a/packages/mcp/src/storage/customer-history.ts
+++ b/packages/mcp/src/storage/customer-history.ts
@@ -56,17 +56,27 @@ const EMPTY: CustomerHistory = { version: 1, jobs: [] };
 
 const writeLocks = new Map<string, Promise<unknown>>();
 
+/**
+ * Test-only: number of in-flight write locks. After every queued write resolves
+ * the map must be empty (see the `withLock` cleanup); a non-zero count after
+ * settle indicates the lock entries are leaking.
+ */
+export function pendingWriteLockCount(): number {
+  return writeLocks.size;
+}
+
 function withLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
   const previous = writeLocks.get(path) ?? Promise.resolve();
   const next = previous.then(fn, fn);
-  writeLocks.set(
-    path,
-    next.finally(() => {
-      if (writeLocks.get(path) === next) {
-        writeLocks.delete(path);
-      }
-    }),
-  );
+  // The map stores `wrapped`, so the cleanup must compare against `wrapped` too -
+  // comparing against `next` (the inner promise) never matched the stored value,
+  // so entries were never deleted and the map grew without bound.
+  const wrapped = next.finally(() => {
+    if (writeLocks.get(path) === wrapped) {
+      writeLocks.delete(path);
+    }
+  });
+  writeLocks.set(path, wrapped);
   return next;
 }
 

--- a/packages/mcp/src/tools/agent.ts
+++ b/packages/mcp/src/tools/agent.ts
@@ -10,7 +10,7 @@ import {
 import { generateSecretKey, nip19 } from 'nostr-tools';
 import { z } from 'zod';
 import { listAgentNames, loadAgentConfig, saveAgentConfig } from '../config.js';
-import type { AgentInstance, AgentSecurityFlags, SolanaNetwork } from '../context.js';
+import type { AgentContext, AgentInstance, AgentSecurityFlags, SolanaNetwork } from '../context.js';
 import { logger } from '../logger.js';
 import type { ToolDefinition } from './types.js';
 import { defineTool, errorResult, textResult } from './types.js';
@@ -119,6 +119,21 @@ export async function buildAgentInstance(
     security: config.security ?? {},
     agentDir: resolved?.dir,
   };
+}
+
+/**
+ * Tear down an agent: close its relay client, zero its Solana secret key bytes,
+ * scrub the Nostr identity, and drop it from the registry. The agent will be
+ * reloaded from disk if switched back to later. Shared by `switch_agent` and
+ * `stop_agent`.
+ */
+function scrubAgent(ctx: AgentContext, agent: AgentInstance): void {
+  agent.client.close();
+  if (agent.solanaKeypair) {
+    agent.solanaKeypair.secretKey.fill(0);
+  }
+  agent.identity.scrub();
+  ctx.registry.delete(agent.name);
 }
 
 export const agentTools: ToolDefinition[] = [
@@ -244,43 +259,48 @@ export const agentTools: ToolDefinition[] = [
         // No active agent yet - allow the switch
       }
 
-      // scrub and close the old agent before switching so secret key bytes
-      // don't linger in memory. The old agent is removed from the registry and
-      // will be reloaded from disk if switched back to later.
+      // Resolve the OLD agent up front (if any) but do NOT tear it down yet. The
+      // target must be loaded and validated FIRST so a bad target name leaves the
+      // current session fully intact. Only after the target is ready do we scrub
+      // and close the old agent so its secret key bytes don't linger in memory.
+      let old: AgentInstance | undefined;
       try {
-        const old = ctx.active();
-        if (old.name !== input.name) {
-          old.client.close();
-          if (old.solanaKeypair) {
-            old.solanaKeypair.secretKey.fill(0);
-          }
-          old.identity.scrub();
-          ctx.registry.delete(old.name);
-        }
+        old = ctx.active();
       } catch {
-        // No active agent - nothing to scrub
+        // No active agent - nothing to scrub later.
       }
 
-      // Check if already loaded
+      // Fast path: target already loaded in the registry. No disk load needed,
+      // so there is nothing to fail - flip the active pointer and scrub the old.
       if (ctx.registry.has(input.name)) {
+        if (old && old.name !== input.name) {
+          scrubAgent(ctx, old);
+        }
         ctx.activeAgentName = input.name;
         const agent = ctx.active();
         const npub = agent.identity.npub;
         return textResult(`Switched to agent "${input.name}" (${npub}).`);
       }
 
-      // Load from disk
+      // Load + build the target from disk FIRST. On any failure here the current
+      // agent is untouched and we surface the error.
+      let instance: AgentInstance;
       try {
         const config = await loadAgentConfig(input.name);
-        const instance = await buildAgentInstance(input.name, config);
-        ctx.register(instance, true);
-
-        const npub = instance.identity.npub;
-        return textResult(`Loaded and switched to agent "${input.name}" (${npub}).`);
+        instance = await buildAgentInstance(input.name, config);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         return errorResult(`Failed to load agent "${input.name}": ${msg}`);
       }
+
+      // Target is ready - now it is safe to tear down the old agent.
+      if (old && old.name !== input.name) {
+        scrubAgent(ctx, old);
+      }
+      ctx.register(instance, true);
+
+      const npub = instance.identity.npub;
+      return textResult(`Loaded and switched to agent "${input.name}" (${npub}).`);
     },
   }),
 
@@ -352,13 +372,8 @@ export const agentTools: ToolDefinition[] = [
         return errorResult(`Agent "${input.name}" is not loaded.`);
       }
 
-      agent.client.close();
-      // best-effort scrub of secret key bytes before dropping the agent.
-      if (agent.solanaKeypair) {
-        agent.solanaKeypair.secretKey.fill(0);
-      }
-      agent.identity.scrub();
-      ctx.registry.delete(input.name);
+      // Close the client, zero secret key bytes, scrub identity, drop from registry.
+      scrubAgent(ctx, agent);
 
       return textResult(`Agent "${input.name}" stopped and removed.`);
     },

--- a/packages/mcp/src/tools/customer.ts
+++ b/packages/mcp/src/tools/customer.ts
@@ -137,6 +137,15 @@ const SubmitAndPayJobFromFileSchema = z.object({
   kind_offset: z.number().int().min(0).max(999).default(DEFAULT_KIND_OFFSET),
   timeout_secs: z.number().int().min(1).max(600).default(300),
   max_price_lamports: z.number().int().optional(),
+  allow_outside_cwd: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Allow reading a file outside the MCP server working directory. Off by default - ' +
+        'the file content is forwarded to the provider before payment and is invisible in ' +
+        'the transcript, so reads are confined to the working dir unless this is set. ' +
+        'Sensitive files (secret keys, .env, SSH/keypair, ~/.elisym, /proc) are always refused.',
+    ),
 });
 
 const SubmitDiffReviewSchema = z.object({
@@ -1137,7 +1146,9 @@ export const customerTools: ToolDefinition[] = [
 
       let payload: string;
       try {
-        payload = await readJobInputFile(input.input_path);
+        payload = await readJobInputFile(input.input_path, {
+          allowOutsideCwd: input.allow_outside_cwd,
+        });
       } catch (e) {
         return errorResult(e instanceof Error ? e.message : String(e));
       }
@@ -1249,12 +1260,21 @@ export const customerTools: ToolDefinition[] = [
         card = provider.cards[0];
       }
       if (!card) {
+        // provider.cards.* is attacker-controlled NIP-89 content - sanitize each
+        // field and wrap the whole payload in the untrusted boundary (#5).
         const available = provider.cards
-          .map((c) => `${c.name} (${c.capabilities?.join(', ')})`)
+          .map(
+            (providerCard) =>
+              `${sanitizeField(providerCard.name ?? '', 64)} (${(providerCard.capabilities ?? [])
+                .map((capability) => sanitizeField(capability, 64))
+                .join(', ')})`,
+          )
           .join('; ');
-        return errorResult(
+        const { text } = sanitizeUntrusted(
           `No capability "${input.capability}" found for provider. Available: ${available}`,
+          'text',
         );
+        return errorResult(text);
       }
 
       const price = card.payment?.job_price ?? 0;
@@ -1270,15 +1290,21 @@ export const customerTools: ToolDefinition[] = [
       // estimate is appended best-effort - RPC failures degrade silently.
       if (price > 0 && input.max_price_lamports === undefined) {
         const gasLine = await gasHintForCardAsset(agent, cardAsset);
+        // provider.name is attacker-controlled kind:0 metadata - sanitize it and
+        // wrap the whole confirmation in the untrusted boundary (#5).
+        const safeProviderName = sanitizeField(provider.name || input.provider_npub, 64);
+        const { text } = sanitizeUntrusted(
+          `Capability "${input.capability}" from "${safeProviderName}" ` +
+            `costs ${formatAssetAmount(cardAsset, BigInt(price))}.${gasLine}\n\n` +
+            `To confirm, call buy_capability again with max_price_lamports set ` +
+            `(e.g. ${price} or higher).`,
+          'text',
+        );
         return {
           content: [
             {
               type: 'text' as const,
-              text:
-                `Capability "${input.capability}" from "${provider.name || input.provider_npub}" ` +
-                `costs ${formatAssetAmount(cardAsset, BigInt(price))}.${gasLine}\n\n` +
-                `To confirm, call buy_capability again with max_price_lamports set ` +
-                `(e.g. ${price} or higher).`,
+              text,
             },
           ],
         };

--- a/packages/mcp/src/tools/dashboard.ts
+++ b/packages/mcp/src/tools/dashboard.ts
@@ -1,9 +1,28 @@
 import { formatAssetAmount } from '@elisym/sdk';
+import type { Agent } from '@elisym/sdk';
 import { z } from 'zod';
 import { sanitizeField, sanitizeUntrusted } from '../sanitize.js';
 import { assetFromCardPayment } from '../utils.js';
 import type { ToolDefinition } from './types.js';
 import { defineTool, textResult } from './types.js';
+
+/** Per-capability-tag display cap before joining into the dashboard row. */
+const MAX_CAPABILITY_TAG_LEN = 64;
+
+/**
+ * Resolve a promise or reject with a clear timeout error after `timeoutMs`.
+ * `fetchAgents` does not accept an AbortSignal, so we bound it with a race; the
+ * underlying query still runs to completion but the caller stops waiting.
+ */
+function withTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`dashboard query timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([work, timeout]).finally(() => clearTimeout(timer));
+}
 
 const GetDashboardSchema = z.object({
   top_n: z.number().int().min(1).max(100).default(10),
@@ -24,25 +43,38 @@ export const dashboardTools: ToolDefinition[] = [
       const agent = ctx.active();
       const network = input.network ?? agent.network;
 
-      const agents = await agent.client.discovery.fetchAgents(network);
+      // Honor the advertised `timeout_secs`: bound the discovery fetch so a slow
+      // or unresponsive relay set cannot hang the tool call indefinitely.
+      let agents: Agent[];
+      try {
+        agents = await withTimeout(
+          agent.client.discovery.fetchAgents(network),
+          input.timeout_secs * 1000,
+        );
+      } catch (e) {
+        return textResult(e instanceof Error ? e.message : String(e));
+      }
 
       // Filter by chain
-      const filtered = agents.filter((a) =>
-        a.cards.some((c) => (c.payment?.chain ?? 'solana') === input.chain),
+      const filtered = agents.filter((candidate) =>
+        candidate.cards.some((card) => (card.payment?.chain ?? 'solana') === input.chain),
       );
 
       // Build rows
       const rows = filtered
-        .map((a) => {
-          const mainCard = a.cards[0];
+        .map((candidate) => {
+          const mainCard = candidate.cards[0];
           const mainAsset = assetFromCardPayment(mainCard?.payment);
           const mainPrice = mainCard?.payment?.job_price;
+          const capabilities = (mainCard?.capabilities ?? [])
+            .map((capability) => sanitizeField(capability, MAX_CAPABILITY_TAG_LEN))
+            .join(', ');
           return {
-            name: sanitizeField(a.name || mainCard?.name || 'unknown', 30),
-            npub: a.npub,
-            capabilities: (mainCard?.capabilities ?? []).join(', '),
+            name: sanitizeField(candidate.name || mainCard?.name || 'unknown', 30),
+            npub: candidate.npub,
+            capabilities,
             price: mainPrice ? formatAssetAmount(mainAsset, BigInt(mainPrice)) : 'free',
-            cards_count: a.cards.length,
+            cards_count: candidate.cards.length,
           };
         })
         .slice(0, input.top_n);
@@ -53,7 +85,10 @@ export const dashboardTools: ToolDefinition[] = [
 
       const header = `elisym Network Dashboard (${network}, ${input.chain})`;
       const table = rows
-        .map((r, i) => `${i + 1}. ${r.name} | ${r.capabilities} | ${r.price} | ${r.npub}`)
+        .map(
+          (row, index) =>
+            `${index + 1}. ${row.name} | ${row.capabilities} | ${row.price} | ${row.npub}`,
+        )
         .join('\n');
 
       const { text } = sanitizeUntrusted(table, 'structured');

--- a/packages/mcp/src/tools/feedback-contacts.ts
+++ b/packages/mcp/src/tools/feedback-contacts.ts
@@ -186,7 +186,11 @@ export const feedbackContactsTools: ToolDefinition[] = [
         contact.name ? `  name: ${contact.name}` : null,
         contact.lastCapability ? `  last capability: ${contact.lastCapability}` : null,
       ].filter((line): line is string => line !== null);
-      return textResult(lines.join('\n'));
+      // contact.name originates from remote discovery data; even though it is
+      // sanitizeField'd above, wrap the response in the untrusted boundary so the
+      // injection scan + markers apply, matching list_contacts (#18).
+      const { text } = sanitizeUntrusted(lines.join('\n'), 'text');
+      return textResult(text);
     },
   }),
 

--- a/packages/mcp/src/tools/policies.ts
+++ b/packages/mcp/src/tools/policies.ts
@@ -1,6 +1,6 @@
 import { LIMITS } from '@elisym/sdk';
 import { z } from 'zod';
-import { sanitizeField, sanitizeInner, sanitizeUntrusted } from '../sanitize.js';
+import { sanitizeField, sanitizeInner, sanitizeUntrusted, scanForInjections } from '../sanitize.js';
 import { decodeNpub } from '../utils.js';
 import type { ToolDefinition } from './types.js';
 import { defineTool, errorResult, textResult } from './types.js';
@@ -33,21 +33,36 @@ export const policiesTools: ToolDefinition[] = [
       const agent = ctx.active();
       const policies = await agent.client.policies.fetchPolicies(pubkey);
 
-      const limited = policies.map((policy) => ({
-        type: policy.type,
-        version: policy.version,
-        title: sanitizeField(policy.title, LIMITS.MAX_POLICY_TITLE_LENGTH),
-        summary: policy.summary
-          ? sanitizeField(policy.summary, LIMITS.MAX_POLICY_SUMMARY_LENGTH)
-          : undefined,
-        content: sanitizeInner(policy.content),
-        naddr: policy.naddr,
-        published_at: policy.publishedAt,
-      }));
+      // Policy bodies are remote free-text. Run the full injection scan over
+      // content/title/summary (mirroring list_my_jobs) so the WARNING banner is
+      // raised when noisy-category injections appear, not just the strict subset.
+      let freetextSuspicious = false;
+      const limited = policies.map((policy) => {
+        const cleanedContent = sanitizeInner(policy.content);
+        if (
+          scanForInjections(cleanedContent, 'full') ||
+          scanForInjections(policy.title ?? '', 'full') ||
+          (policy.summary ? scanForInjections(policy.summary, 'full') : false)
+        ) {
+          freetextSuspicious = true;
+        }
+        return {
+          type: policy.type,
+          version: policy.version,
+          title: sanitizeField(policy.title, LIMITS.MAX_POLICY_TITLE_LENGTH),
+          summary: policy.summary
+            ? sanitizeField(policy.summary, LIMITS.MAX_POLICY_SUMMARY_LENGTH)
+            : undefined,
+          content: cleanedContent,
+          naddr: policy.naddr,
+          published_at: policy.publishedAt,
+        };
+      });
 
       const { text } = sanitizeUntrusted(
         JSON.stringify({ count: limited.length, policies: limited }, null, 2),
         'structured',
+        { extraInjectionSignal: freetextSuspicious },
       );
       return textResult(text);
     },

--- a/packages/mcp/src/tools/wallet.ts
+++ b/packages/mcp/src/tools/wallet.ts
@@ -209,8 +209,9 @@ export const walletTools: ToolDefinition[] = [
 
       const rpc = rpcFor(agent);
       const walletAddress = address(agent.solanaKeypair.publicKey);
+      // balanceLamports is a bigint; keep it bigint end-to-end. Routing it
+      // through Number() would lose precision past 2^53 lamports (money rule).
       const { value: balanceLamports } = await rpc.getBalance(walletAddress).send();
-      const balance = Number(balanceLamports);
 
       const usdcBalanceRaw = await fetchUsdcBalance(rpc, walletAddress);
       const usdcLine = `USDC balance: ${formatAssetAmount(USDC_SOLANA_DEVNET, usdcBalanceRaw)}`;
@@ -221,7 +222,7 @@ export const walletTools: ToolDefinition[] = [
       return textResult(
         `Address: ${agent.solanaKeypair.publicKey}\n` +
           `Network: ${agent.network}\n` +
-          `Balance: ${formatSol(BigInt(balance))} (${balance} lamports)\n` +
+          `Balance: ${formatSol(balanceLamports)} (${balanceLamports.toString()} lamports)\n` +
           usdcLine +
           sessionBlock,
       );
@@ -354,9 +355,24 @@ export const walletTools: ToolDefinition[] = [
         throw e;
       }
 
-      const { value: balanceLamports } = await rpc
-        .getBalance(address(agent.solanaKeypair.publicKey))
-        .send();
+      // The payment already committed on-chain above. A failing balance fetch
+      // here (RPC hiccup, rate limit) must NOT make send_payment report failure -
+      // the funds have moved. Best-effort: report the remaining balance when we
+      // can fetch it, otherwise omit that line.
+      let remainingBalanceLine = '';
+      try {
+        const { value: balanceLamports } = await rpc
+          .getBalance(address(agent.solanaKeypair.publicKey))
+          .send();
+        remainingBalanceLine = `  Remaining SOL balance: ${formatSol(balanceLamports)}\n`;
+      } catch (e) {
+        logger.warn(
+          { event: 'post_payment_balance_fetch_failed', agent: agent.name },
+          `Payment succeeded but the post-confirmation balance fetch failed: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
 
       // One-shot 50% / 80% warnings fire only after successful on-chain commit.
       const warnings = takeSpendWarnings(ctx, sendAsset);
@@ -371,7 +387,7 @@ export const walletTools: ToolDefinition[] = [
           `  Signature: ${signature}\n` +
           `  Amount: ${formatAssetAmount(paidAsset, BigInt(requestData.amount))}\n` +
           `  Recipient: ${requestData.recipient}\n` +
-          `  Remaining SOL balance: ${formatSol(balanceLamports)}\n` +
+          remainingBalanceLine +
           `  Explorer: ${explorerUrl(agent, signature)}`,
       );
     },

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -49,9 +49,11 @@ export function formatSolNumeric(lamports: bigint): string {
 
 /** Format lamports as "X.XXXX SOL" (4 decimal places, truncated). */
 export function formatSolShort(lamports: bigint): string {
-  const whole = lamports / LAMPORTS_PER_SOL;
-  const frac = (lamports % LAMPORTS_PER_SOL) / 100_000n;
-  return `${whole}.${frac.toString().padStart(4, '0')} SOL`;
+  const sign = lamports < 0n ? '-' : '';
+  const abs = lamports < 0n ? -lamports : lamports;
+  const whole = abs / LAMPORTS_PER_SOL;
+  const frac = (abs % LAMPORTS_PER_SOL) / 100_000n;
+  return `${sign}${whole}.${frac.toString().padStart(4, '0')} SOL`;
 }
 
 /**

--- a/packages/mcp/tests/customer-history.test.ts
+++ b/packages/mcp/tests/customer-history.test.ts
@@ -8,6 +8,7 @@ import {
   appendCustomerJob,
   findCustomerJob,
   findCustomerJobsByProvider,
+  pendingWriteLockCount,
   readCustomerHistory,
   updateCustomerJob,
   type CustomerJobEntry,
@@ -155,6 +156,29 @@ describe('customer-history', () => {
     );
     const results = await findCustomerJobsByProvider(agentDir, PROVIDER_A);
     expect(results.map((entry) => entry.jobEventId)).toEqual(['new', 'old']);
+  });
+
+  // The lock entry is removed inside a `.finally` that runs as a microtask after
+  // the append promise settles, so we flush the microtask/macrotask queue with a
+  // setTimeout(0) before asserting the map is empty.
+  function flushTasks(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it('releases the write lock after an append resolves (no map leak)', async () => {
+    await appendCustomerJob(agentDir, makeEntry());
+    await flushTasks();
+    expect(pendingWriteLockCount()).toBe(0);
+  });
+
+  it('releases all write locks after concurrent appends settle', async () => {
+    await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        appendCustomerJob(agentDir, makeEntry({ jobEventId: `leak-${index}` })),
+      ),
+    );
+    await flushTasks();
+    expect(pendingWriteLockCount()).toBe(0);
   });
 
   it('returns an empty history when the file is corrupt', async () => {

--- a/packages/mcp/tests/global-config-roundtrip.test.ts
+++ b/packages/mcp/tests/global-config-roundtrip.test.ts
@@ -30,12 +30,14 @@ describe('global config roundtrip', () => {
     expect(cfg).toEqual({});
   });
 
-  it('roundtrips a SOL entry', async () => {
+  it('roundtrips a SOL entry (legacy numeric amount normalized to string)', async () => {
     await writeGlobalConfig(globalConfigPath(), {
       session_spend_limits: [{ chain: 'solana', token: 'sol', amount: 0.5 }],
     });
     const cfg = await loadGlobalConfig(globalConfigPath());
-    expect(cfg.session_spend_limits).toEqual([{ chain: 'solana', token: 'sol', amount: 0.5 }]);
+    // The schema now stores amount as a string (preserving exact decimal text);
+    // a legacy numeric value is accepted and normalized to its string form.
+    expect(cfg.session_spend_limits).toEqual([{ chain: 'solana', token: 'sol', amount: '0.5' }]);
   });
 
   it('throws on malformed YAML', async () => {

--- a/packages/mcp/tests/job-input.test.ts
+++ b/packages/mcp/tests/job-input.test.ts
@@ -46,34 +46,64 @@ describe('readJobInputFile', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  // The temp files live outside the package cwd, so pass allowOutsideCwd to
+  // exercise the underlying read behavior; confinement is covered separately below.
   it('reads a regular file as utf-8', async () => {
     const p = join(dir, 'in.txt');
     await writeFile(p, 'hello world');
-    expect(await readJobInputFile(p)).toBe('hello world');
+    expect(await readJobInputFile(p, { allowOutsideCwd: true })).toBe('hello world');
   });
 
   it('rejects a missing file with a path-bearing message', async () => {
     const p = join(dir, 'does-not-exist.txt');
-    await expect(readJobInputFile(p)).rejects.toThrow(/does not exist/);
+    await expect(readJobInputFile(p, { allowOutsideCwd: true })).rejects.toThrow(/does not exist/);
   });
 
   it('rejects a directory path (not a regular file)', async () => {
     const sub = join(dir, 'sub');
     await mkdir(sub);
-    await expect(readJobInputFile(sub)).rejects.toThrow(/not a regular file/);
+    await expect(readJobInputFile(sub, { allowOutsideCwd: true })).rejects.toThrow(
+      /not a regular file/,
+    );
   });
 
   it('rejects oversize content via stat()', async () => {
     const p = join(dir, 'big.txt');
     // 1 byte over the 100_000 limit.
     await writeFile(p, 'a'.repeat(100_001));
-    await expect(readJobInputFile(p)).rejects.toThrow(/too large/);
+    await expect(readJobInputFile(p, { allowOutsideCwd: true })).rejects.toThrow(/too large/);
   });
 
   it('rejects an excessively long path argument before touching the FS', async () => {
     // Construct a path string longer than MAX_INPUT_PATH_LEN (4096).
     const huge = 'x'.repeat(5000);
     await expect(readJobInputFile(huge)).rejects.toThrow(/too long/);
+  });
+
+  it('refuses a path outside the working directory unless allow_outside_cwd is set', async () => {
+    const p = join(dir, 'outside.txt');
+    await writeFile(p, 'data');
+    // Default: confined to cwd subtree (the temp dir is outside it).
+    await expect(readJobInputFile(p)).rejects.toThrow(/outside the working directory/);
+  });
+
+  it('always refuses sensitive files even with allow_outside_cwd', async () => {
+    const secret = join(dir, '.secrets.json');
+    await writeFile(secret, '{"nostr_secret_key":"x"}');
+    await expect(readJobInputFile(secret, { allowOutsideCwd: true })).rejects.toThrow(
+      /sensitive file/,
+    );
+  });
+
+  it('reads a file inside the working directory by default', async () => {
+    // A file under process.cwd() is allowed without the opt-in.
+    const p = join(process.cwd(), `elisym-jobinput-test-${Date.now()}.txt`);
+    await writeFile(p, 'inside cwd');
+    try {
+      expect(await readJobInputFile(p)).toBe('inside cwd');
+    } finally {
+      await rm(p, { force: true });
+    }
   });
 });
 

--- a/packages/mcp/tests/utils.test.ts
+++ b/packages/mcp/tests/utils.test.ts
@@ -45,6 +45,14 @@ describe('formatSolShort', () => {
   it('formats whole SOL', () => {
     expect(formatSolShort(1_000_000_000n)).toBe('1.0000 SOL');
   });
+
+  it('formats negative lamports with a leading minus sign', () => {
+    expect(formatSolShort(-1_500_000_000n)).toBe('-1.5000 SOL');
+  });
+
+  it('formats a small negative amount', () => {
+    expect(formatSolShort(-10_000_000n)).toBe('-0.0100 SOL');
+  });
 });
 
 describe('parseSolToLamports', () => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/sdk",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "TypeScript SDK for elisym - AI agent discovery, marketplace, and payments on Nostr",
   "keywords": [
     "ai-agents",

--- a/packages/sdk/src/config/global-schema.ts
+++ b/packages/sdk/src/config/global-schema.ts
@@ -17,7 +17,15 @@ export const SessionSpendLimitEntrySchema = z
       .max(16)
       .regex(/^[a-z0-9]+$/, 'token must be lowercase alphanumeric'),
     mint: z.string().min(1).max(64).optional(),
-    amount: z.number().positive().finite(),
+    // Stored as a string to preserve the operator's exact decimal text (avoids
+    // Number round-tripping to scientific notation). Legacy configs persisted a
+    // number; accept both and normalize to a positive-decimal string.
+    amount: z
+      .union([z.string(), z.number()])
+      .transform((value) => (typeof value === 'number' ? String(value) : value.trim()))
+      .refine((value) => /^\d+(?:\.\d+)?$/.test(value) && /[1-9]/.test(value), {
+        message: 'amount must be a positive decimal (e.g. "0.5", "1")',
+      }),
   })
   .strict();
 

--- a/packages/sdk/src/llm-health/index.ts
+++ b/packages/sdk/src/llm-health/index.ts
@@ -13,6 +13,7 @@ export {
 export {
   LlmHealthError,
   ScriptBillingExhaustedError,
+  ScriptExecutionError,
   type LlmHealthErrorReason,
   type LlmHealthSnapshotEntry,
   type LlmHealthStatus,

--- a/packages/sdk/src/llm-health/types.ts
+++ b/packages/sdk/src/llm-health/types.ts
@@ -72,6 +72,25 @@ export class ScriptBillingExhaustedError extends Error {
 }
 
 /**
+ * Thrown by the SDK script skills when a tool/script fails (non-zero exit, spawn
+ * error, or exit 0 with empty output). `message` is a generic, stable summary
+ * that is SAFE to forward to a remote customer. The raw stderr/stdout lives on
+ * `detail` for the operator log and health-monitor classification ONLY - it must
+ * never be sent across the trust boundary to a customer.
+ */
+export class ScriptExecutionError extends Error {
+  readonly exitCode: number | null;
+  readonly detail: string;
+
+  constructor(exitCode: number | null, detail: string, summary?: string) {
+    super(summary ?? `script failed (exit ${exitCode ?? 'unknown'})`);
+    this.name = 'ScriptExecutionError';
+    this.exitCode = exitCode;
+    this.detail = detail;
+  }
+}
+
+/**
  * Per-skill rate-limit declaration. Snake-case in SKILL.md frontmatter,
  * camelCase here. Applies to any skill mode but the framework adds a
  * default cap only for free LLM skills.

--- a/packages/sdk/src/payment/analytics.ts
+++ b/packages/sdk/src/payment/analytics.ts
@@ -181,6 +181,12 @@ function accumulateNativeDeltas(
  * Returns `null` when the PDA has not been initialized yet (admin must call
  * `initialize_stats` once after program upgrade).
  */
+/**
+ * Best-effort network counters read from the on-chain PDA. These are NOT bound
+ * to verified transfers and can be inflated by a malicious caller, so present
+ * them as approximate/unverified, never as authoritative proof of activity. For
+ * a transfer-derived figure use `aggregateNetworkStats`.
+ */
 export interface OnchainNetworkStats {
   jobCount: number;
   volumeNative: bigint;

--- a/packages/sdk/src/payment/quick-verify.ts
+++ b/packages/sdk/src/payment/quick-verify.ts
@@ -21,7 +21,16 @@ export type QuickVerifyReason =
   | 'invalid_input';
 
 export interface QuickVerifyResult {
-  verified: boolean;
+  /**
+   * True when the recipient address received funds in this transaction.
+   *
+   * NOTE: this is NOT proof of a valid elisym job payment. It does not check
+   * the payment `reference` key or that the amount matches the job price - it
+   * is a best-effort signal for the fast discovery-ranking path, where the
+   * original payment request is unavailable. For an authoritative check
+   * (amount + reference) use `SolanaPaymentStrategy.verifyPayment`.
+   */
+  receivedFunds: boolean;
   txSignature: string;
   reason?: QuickVerifyReason;
 }
@@ -32,6 +41,8 @@ interface VerifyCacheEntry {
 }
 
 const NEGATIVE_CACHE_TTL_MS = 60_000;
+// Cap so a long-running process cannot grow the cache without bound (#44).
+const MAX_CACHE_ENTRIES = 5_000;
 
 const verifyCache = new Map<string, VerifyCacheEntry>();
 
@@ -45,24 +56,33 @@ export async function verifyJobPaymentQuick(
   expectedRecipient: Address,
 ): Promise<QuickVerifyResult> {
   if (!txSignature) {
-    return { verified: false, txSignature: '', reason: 'invalid_input' };
+    return { receivedFunds: false, txSignature: '', reason: 'invalid_input' };
   }
   if (!expectedRecipient || !isAddress(expectedRecipient as string)) {
-    return { verified: false, txSignature, reason: 'invalid_input' };
+    return { receivedFunds: false, txSignature, reason: 'invalid_input' };
   }
 
   const cacheKey = `${txSignature}:${expectedRecipient}`;
   const cached = verifyCache.get(cacheKey);
   if (cached) {
-    if (cached.result.verified) {
+    if (cached.result.receivedFunds) {
       return cached.result;
     }
     if (Date.now() - cached.cachedAt < NEGATIVE_CACHE_TTL_MS) {
       return cached.result;
     }
+    // Expired negative result - drop it so re-verification can refresh.
+    verifyCache.delete(cacheKey);
   }
 
   const result = await doVerifyOnce(rpc, txSignature as Signature, expectedRecipient);
+  // Map preserves insertion order, so evicting the first key is LRU-ish.
+  if (verifyCache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = verifyCache.keys().next().value;
+    if (oldest !== undefined) {
+      verifyCache.delete(oldest);
+    }
+  }
   verifyCache.set(cacheKey, { result, cachedAt: Date.now() });
   return result;
 }
@@ -82,7 +102,7 @@ async function doVerifyOnce(
   const sigStr = txSignature as string;
 
   if (!rpc || typeof (rpc as { getTransaction?: unknown }).getTransaction !== 'function') {
-    return { verified: false, txSignature: sigStr, reason: 'rpc_error' };
+    return { receivedFunds: false, txSignature: sigStr, reason: 'rpc_error' };
   }
 
   let tx: Awaited<ReturnType<ReturnType<Rpc<SolanaRpcApi>['getTransaction']>['send']>>;
@@ -95,14 +115,14 @@ async function doVerifyOnce(
       })
       .send();
   } catch {
-    return { verified: false, txSignature: sigStr, reason: 'rpc_error' };
+    return { receivedFunds: false, txSignature: sigStr, reason: 'rpc_error' };
   }
 
   if (!tx) {
-    return { verified: false, txSignature: sigStr, reason: 'not_found' };
+    return { receivedFunds: false, txSignature: sigStr, reason: 'not_found' };
   }
   if (!tx.meta || tx.meta.err) {
-    return { verified: false, txSignature: sigStr, reason: 'tx_failed' };
+    return { receivedFunds: false, txSignature: sigStr, reason: 'tx_failed' };
   }
 
   const accountKeys = tx.transaction.message.accountKeys as readonly string[];
@@ -118,7 +138,7 @@ async function doVerifyOnce(
       if (pre !== undefined && post !== undefined) {
         const delta = BigInt(post) - BigInt(pre);
         if (delta > 0n) {
-          return { verified: true, txSignature: sigStr };
+          return { receivedFunds: true, txSignature: sigStr };
         }
       }
     }
@@ -137,10 +157,10 @@ async function doVerifyOnce(
       const preAmount = pre ? BigInt(pre.uiTokenAmount.amount) : 0n;
       const postAmount = BigInt(post.uiTokenAmount.amount);
       if (postAmount > preAmount) {
-        return { verified: true, txSignature: sigStr };
+        return { receivedFunds: true, txSignature: sigStr };
       }
     }
   }
 
-  return { verified: false, txSignature: sigStr, reason: 'recipient_mismatch' };
+  return { receivedFunds: false, txSignature: sigStr, reason: 'recipient_mismatch' };
 }

--- a/packages/sdk/src/services/discovery.ts
+++ b/packages/sdk/src/services/discovery.ts
@@ -449,6 +449,10 @@ export class DiscoveryService {
     // an unmatched feedback means the provider never delivered (or never
     // existed at the time), so it must not count as a verified paid job.
     const deliveredJobsByProvider = new Map<string, Set<string>>();
+    // jobEventId -> the customer pubkey the provider addressed the result to
+    // (the result's `p` tag is `requestEvent.pubkey`, see submitJobResult). Used
+    // to bind feedback/rating authorship to the job's actual customer below.
+    const customerByJob = new Map<string, string>();
     for (const ev of resultEvents) {
       if (!verifyEvent(ev)) {
         continue;
@@ -468,13 +472,22 @@ export class DiscoveryService {
           deliveredJobsByProvider.set(ev.pubkey, delivered);
         }
         delivered.add(jobEventId);
+        const customerPubkey = ev.tags.find((tag) => tag[0] === 'p')?.[1];
+        if (customerPubkey) {
+          customerByJob.set(jobEventId, customerPubkey);
+        }
       }
     }
 
     // Feedback events: written by the *customer*, target agent in the `p` tag.
     // Tally rating counters and pick the newest `payment-completed` feedback
-    // per agent as `lastPaidJobAt` / `lastPaidJobTx`, but only when the same
-    // job has a matching kind:6xxx result from the provider.
+    // per agent as `lastPaidJobAt` / `lastPaidJobTx`. A feedback only counts
+    // when (a) it references a job (`e` tag) that has a matching kind:6xxx
+    // result from the provider, and (b) its author is the customer that result
+    // was addressed to. This blocks unauthenticated third parties from inflating
+    // ratings / minting paid-job timestamps. Provider-vs-sock-puppet collusion
+    // still needs on-chain payment verification (roadmap).
+    const countedRatings = new Set<string>();
     for (const ev of feedbackEvents) {
       if (!verifyEvent(ev)) {
         continue;
@@ -491,26 +504,36 @@ export class DiscoveryService {
         agent.lastSeen = ev.created_at;
       }
 
+      const jobEventId = ev.tags.find((tag) => tag[0] === 'e')?.[1];
+      const hasDeliveredResult =
+        jobEventId !== undefined &&
+        deliveredJobsByProvider.get(targetPubkey)?.has(jobEventId) === true;
+      // Was this feedback authored by the job's actual customer?
+      const jobCustomer = jobEventId !== undefined ? customerByJob.get(jobEventId) : undefined;
+      const authoredByCustomer = jobCustomer !== undefined && ev.pubkey === jobCustomer;
+
       const rating = ev.tags.find((tag) => tag[0] === 'rating')?.[1];
-      if (rating === '1' || rating === '0') {
-        agent.totalRatingCount = (agent.totalRatingCount ?? 0) + 1;
-        if (rating === '1') {
-          agent.positiveCount = (agent.positiveCount ?? 0) + 1;
+      if ((rating === '1' || rating === '0') && hasDeliveredResult && authoredByCustomer) {
+        // Dedupe: at most one rating per (customer, job).
+        const ratingKey = `${ev.pubkey}:${jobEventId}`;
+        if (!countedRatings.has(ratingKey)) {
+          countedRatings.add(ratingKey);
+          agent.totalRatingCount = (agent.totalRatingCount ?? 0) + 1;
+          if (rating === '1') {
+            agent.positiveCount = (agent.positiveCount ?? 0) + 1;
+          }
         }
       }
 
       const status = ev.tags.find((tag) => tag[0] === 'status')?.[1];
       const txTag = ev.tags.find((tag) => tag[0] === 'tx');
       const txSignature = txTag?.[1];
-      const jobEventId = ev.tags.find((tag) => tag[0] === 'e')?.[1];
-      const hasDeliveredResult =
-        jobEventId !== undefined &&
-        deliveredJobsByProvider.get(targetPubkey)?.has(jobEventId) === true;
       if (
         status === 'payment-completed' &&
         typeof txSignature === 'string' &&
         txSignature &&
-        hasDeliveredResult
+        hasDeliveredResult &&
+        authoredByCustomer
       ) {
         if (!agent.lastPaidJobAt || ev.created_at > agent.lastPaidJobAt) {
           agent.lastPaidJobAt = ev.created_at;

--- a/packages/sdk/src/skills/dynamicScriptSkill.ts
+++ b/packages/sdk/src/skills/dynamicScriptSkill.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path';
 import { SCRIPT_EXIT_BILLING_EXHAUSTED } from '../llm-health/constants';
-import { ScriptBillingExhaustedError } from '../llm-health/types';
+import { ScriptBillingExhaustedError, ScriptExecutionError } from '../llm-health/types';
 import type { Asset } from '../payment/assets';
 import { runScript } from './scriptSkill';
 import type {
@@ -86,14 +86,20 @@ export class DynamicScriptSkill implements Skill {
       env: this.scriptEnv,
     });
     if (result.spawnError) {
-      throw new Error(`script spawn failed: ${result.spawnError.message}`);
+      throw new ScriptExecutionError(
+        null,
+        result.spawnError.message,
+        'script could not be started',
+      );
     }
     if (result.code === SCRIPT_EXIT_BILLING_EXHAUSTED) {
       throw new ScriptBillingExhaustedError(result.code, result.stdout, result.stderr);
     }
     if (result.code !== 0) {
       const detail = result.stderr.trim() || result.stdout.trim() || '(no output)';
-      throw new Error(`script failed (exit ${result.code}): ${detail}`);
+      // Generic message reaches the customer; raw stderr/stdout stays on `detail`
+      // for the operator log and health-monitor classification only.
+      throw new ScriptExecutionError(result.code, detail);
     }
     const output = result.stdout.trim();
     if (output === '') {
@@ -104,7 +110,7 @@ export class DynamicScriptSkill implements Skill {
       // paid -> failed path so recovery terminates it. stderr (if any)
       // carries the underlying reason for the operator log.
       const detail = result.stderr.trim() || '(no stderr)';
-      throw new Error(`script exited 0 but produced empty output: ${detail}`);
+      throw new ScriptExecutionError(result.code, detail, 'script produced empty output');
     }
     return { data: output };
   }

--- a/packages/sdk/src/skills/loader.ts
+++ b/packages/sdk/src/skills/loader.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import YAML from 'yaml';
-import { LAMPORTS_PER_SOL, LIMITS } from '../constants';
+import { LIMITS } from '../constants';
 import type { SkillRateLimit } from '../llm-health/types';
 import {
   type Asset,
@@ -133,11 +133,18 @@ export interface LoadSkillsOptions {
 }
 
 function solToLamports(sol: string | number): bigint {
-  const asNumber = typeof sol === 'string' ? Number(sol) : sol;
-  if (!Number.isFinite(asNumber) || asNumber < 0) {
+  const asString = (typeof sol === 'string' ? sol : String(sol)).trim();
+  // Free skills declare price 0; `parseAssetAmount` rejects non-positive amounts,
+  // so the zero case is handled here. Everything else goes through the exact
+  // integer/string parser - no floating-point multiply (see money-math rule).
+  if (/^0+(?:\.0+)?$/.test(asString)) {
+    return 0n;
+  }
+  try {
+    return parseAssetAmount(NATIVE_SOL, asString);
+  } catch {
     throw new Error(`Invalid SOL amount: ${sol}`);
   }
-  return BigInt(Math.round(asNumber * LAMPORTS_PER_SOL));
 }
 
 /**
@@ -495,11 +502,10 @@ export function validateSkillFrontmatter(
     }
     const priceString = typeof priceRaw === 'number' ? String(priceRaw) : priceRaw;
     if (asset === NATIVE_SOL) {
-      // Preserve historical rounding behaviour: number * LAMPORTS_PER_SOL +
-      // Math.round. `parseAssetAmount` would reject non-positive inputs before
-      // we could check `allowFreeSkills`, so we keep the legacy path for SOL
-      // and introduce the strict parser only for new token types.
-      priceSubunits = solToLamports(priceRaw);
+      // SOL prices route through `solToLamports`, which uses the same exact
+      // integer parser as other assets but tolerates a 0 price so the
+      // `allowFreeSkills` check below can run (parseAssetAmount rejects 0).
+      priceSubunits = solToLamports(priceString);
     } else {
       try {
         priceSubunits = parseAssetAmount(asset, priceString);
@@ -637,6 +643,18 @@ export function validateSkillFrontmatter(
 }
 
 function buildSkillFromParsed(parsed: ParsedSkill, skillDir: string, logger: LoaderLogger): Skill {
+  // Containment for `image_file`, matching `script`/`output_file` (which throw).
+  // The image is decorative, so an out-of-dir path is dropped with a warning
+  // rather than failing the load. Without this, `image_file: ../../.secrets.json`
+  // would be read and uploaded to a public media host at startup (exfiltration).
+  let imageFile = parsed.imageFile;
+  if (imageFile !== undefined && resolveInsidePath(skillDir, imageFile) === null) {
+    logger.warn?.(
+      { skill: parsed.name, imageFile },
+      'SKILL.md "image_file" escapes the skill directory; ignoring it',
+    );
+    imageFile = undefined;
+  }
   switch (parsed.mode) {
     case 'llm':
       return new ScriptSkill({
@@ -651,7 +669,7 @@ function buildSkillFromParsed(parsed: ParsedSkill, skillDir: string, logger: Loa
         maxToolRounds: parsed.maxToolRounds,
         llmOverride: parsed.llmOverride,
         image: parsed.image,
-        imageFile: parsed.imageFile,
+        imageFile,
         logger,
       });
     case 'static-file': {
@@ -674,7 +692,7 @@ function buildSkillFromParsed(parsed: ParsedSkill, skillDir: string, logger: Loa
         asset: parsed.asset,
         outputFilePath,
         image: parsed.image,
-        imageFile: parsed.imageFile,
+        imageFile,
         llmOverride: parsed.llmOverride,
       });
     }
@@ -700,7 +718,7 @@ function buildSkillFromParsed(parsed: ParsedSkill, skillDir: string, logger: Loa
         scriptArgs: parsed.scriptArgs,
         scriptTimeoutMs: parsed.scriptTimeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS,
         image: parsed.image,
-        imageFile: parsed.imageFile,
+        imageFile,
         llmOverride: parsed.llmOverride,
       });
     }

--- a/packages/sdk/src/skills/scriptSkill.ts
+++ b/packages/sdk/src/skills/scriptSkill.ts
@@ -128,6 +128,19 @@ export function runScript(
   });
 }
 
+// Env vars that carry agent/operator secrets and must not leak into skill tool
+// subprocesses. The child still inherits the rest of the environment (PATH,
+// HOME, locale, etc.) so legitimate tool scripts keep working.
+const SECRET_ENV_VARS: readonly string[] = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
+
+function scopedToolEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of SECRET_ENV_VARS) {
+    delete env[key];
+  }
+  return env;
+}
+
 export interface ScriptSkillParams {
   name: string;
   description: string;
@@ -291,14 +304,28 @@ export class ScriptSkill implements Skill {
       if (value === undefined) {
         continue;
       }
+      const stringValue = String(value);
+      // Reject values beginning with `-` so an LLM-supplied argument can never be
+      // parsed as an option/flag by the target script (argument injection, #25). We
+      // deliberately do NOT insert a `--` end-of-options sentinel: many tool scripts
+      // read positionals directly ($1) and would receive the literal `--` as input.
+      if (stringValue.startsWith('-')) {
+        return `Error: tool "${toolDef.name}" argument "${param.name}" must not begin with "-".`;
+      }
       if (param.required && index === 0) {
-        args.push(String(value));
+        args.push(stringValue);
       } else {
-        args.push(`--${param.name}`, String(value));
+        args.push(`--${param.name}`, stringValue);
       }
     }
 
-    const result = await runScript(cmd, args, { cwd: this.skillDir, signal });
+    // Scoped env: strip operator secrets (LLM API keys) so an untrusted tool
+    // script cannot read them out of its environment.
+    const result = await runScript(cmd, args, {
+      cwd: this.skillDir,
+      signal,
+      env: scopedToolEnv(),
+    });
 
     if (result.spawnError) {
       return `Error: ${result.spawnError.message}`;

--- a/packages/sdk/src/skills/staticScriptSkill.ts
+++ b/packages/sdk/src/skills/staticScriptSkill.ts
@@ -1,6 +1,6 @@
 import { dirname } from 'node:path';
 import { SCRIPT_EXIT_BILLING_EXHAUSTED } from '../llm-health/constants';
-import { ScriptBillingExhaustedError } from '../llm-health/types';
+import { ScriptBillingExhaustedError, ScriptExecutionError } from '../llm-health/types';
 import type { Asset } from '../payment/assets';
 import { runScript } from './scriptSkill';
 import type {
@@ -85,14 +85,20 @@ export class StaticScriptSkill implements Skill {
       env: this.scriptEnv,
     });
     if (result.spawnError) {
-      throw new Error(`script spawn failed: ${result.spawnError.message}`);
+      throw new ScriptExecutionError(
+        null,
+        result.spawnError.message,
+        'script could not be started',
+      );
     }
     if (result.code === SCRIPT_EXIT_BILLING_EXHAUSTED) {
       throw new ScriptBillingExhaustedError(result.code, result.stdout, result.stderr);
     }
     if (result.code !== 0) {
       const detail = result.stderr.trim() || result.stdout.trim() || '(no output)';
-      throw new Error(`script failed (exit ${result.code}): ${detail}`);
+      // Generic message reaches the customer; raw stderr/stdout stays on `detail`
+      // for the operator log and health-monitor classification only.
+      throw new ScriptExecutionError(result.code, detail);
     }
     const output = result.stdout.trim();
     if (output === '') {
@@ -103,7 +109,7 @@ export class StaticScriptSkill implements Skill {
       // paid -> failed path so recovery terminates it. stderr (if any)
       // carries the underlying reason for the operator log.
       const detail = result.stderr.trim() || '(no stderr)';
-      throw new Error(`script exited 0 but produced empty output: ${detail}`);
+      throw new ScriptExecutionError(result.code, detail, 'script produced empty output');
     }
     return { data: output };
   }

--- a/packages/sdk/tests/discovery.stream.test.ts
+++ b/packages/sdk/tests/discovery.stream.test.ts
@@ -300,7 +300,12 @@ describe('DiscoveryService.streamAgents', () => {
     const jobEventId = 'real-job-id';
     const ts = Math.floor(Date.now() / 1000);
 
-    queryBatched.mockResolvedValueOnce([makeResultEvent(provider, jobEventId, { createdAt: ts })]);
+    // Real result events tag the customer (requestEvent.pubkey) in `p`; the
+    // discovery ranking binds the feedback author to that customer, so the
+    // fixture must include it for the legit "customer rated their own job" path.
+    queryBatched.mockResolvedValueOnce([
+      makeResultEvent(provider, jobEventId, { createdAt: ts, tags: [['p', customer.publicKey]] }),
+    ]);
     queryBatchedByTag.mockResolvedValueOnce([
       makeFeedbackEvent(customer, provider.publicKey, {
         status: 'payment-completed',

--- a/packages/sdk/tests/discovery.test.ts
+++ b/packages/sdk/tests/discovery.test.ts
@@ -562,11 +562,17 @@ function makeResultEvent(
     createdAt: number;
     kind?: number;
     jobEventId?: string;
+    customerPubkey?: string;
   } = { createdAt: Math.floor(Date.now() / 1000) },
 ): Event {
   const tags: string[][] = [];
   if (opts.jobEventId) {
     tags.push(['e', opts.jobEventId]);
+  }
+  // Real result events tag the customer (requestEvent.pubkey) in `p`; discovery
+  // ranking binds rating/payment feedback authorship to this customer.
+  if (opts.customerPubkey) {
+    tags.push(['p', opts.customerPubkey]);
   }
   return finalizeEvent(
     {
@@ -577,6 +583,39 @@ function makeResultEvent(
     },
     agent.secretKey,
   );
+}
+
+/**
+ * Build a feedback + matching result event for one delivered, customer-rated job.
+ * The result is tagged to the customer (`p`) so the rating/payment counts under the
+ * authorship binding; each call uses a distinct jobEventId so ratings dedupe correctly.
+ */
+function ratedJob(
+  provider: ElisymIdentity,
+  customer: ElisymIdentity,
+  jobEventId: string,
+  opts: {
+    feedbackAt: number;
+    resultAt: number;
+    rating?: '0' | '1';
+    status?: string;
+    txSignature?: string;
+  },
+): { feedback: Event; result: Event } {
+  return {
+    feedback: makeFeedbackEvent(customer, provider.publicKey, {
+      createdAt: opts.feedbackAt,
+      jobEventId,
+      rating: opts.rating,
+      status: opts.status,
+      txSignature: opts.txSignature,
+    }),
+    result: makeResultEvent(provider, {
+      createdAt: opts.resultAt,
+      jobEventId,
+      customerPubkey: customer.publicKey,
+    }),
+  };
 }
 
 interface RoutedPool extends NostrPool {
@@ -639,31 +678,51 @@ describe('DiscoveryService.fetchAgents ranking', () => {
       }),
     );
 
-    const jobA1 = 'job-a1';
-    const jobA2 = 'job-a2';
-    const feedbacks = [
-      makeFeedbackEvent(customer, a1.publicKey, {
-        createdAt: now - 10,
+    // Each rating/payment is its own delivered, customer-bound job (the ranking
+    // now only counts feedback authored by the job's actual customer).
+    const jobs = [
+      // a1: paid + ratings [1, 0, 0] -> 1/3 positive.
+      ratedJob(a1, customer, 'job-a1-paid', {
+        feedbackAt: now - 10,
+        resultAt: now - 11,
         status: 'payment-completed',
         txSignature: 'sig-a1',
-        jobEventId: jobA1,
       }),
-      makeFeedbackEvent(customer, a1.publicKey, { createdAt: now - 50, rating: '1' }),
-      makeFeedbackEvent(customer, a1.publicKey, { createdAt: now - 51, rating: '0' }),
-      makeFeedbackEvent(customer, a1.publicKey, { createdAt: now - 52, rating: '0' }),
-      makeFeedbackEvent(customer, a2.publicKey, {
-        createdAt: now - 15,
+      ratedJob(a1, customer, 'job-a1-r0', {
+        feedbackAt: now - 50,
+        resultAt: now - 51,
+        rating: '1',
+      }),
+      ratedJob(a1, customer, 'job-a1-r1', {
+        feedbackAt: now - 51,
+        resultAt: now - 52,
+        rating: '0',
+      }),
+      ratedJob(a1, customer, 'job-a1-r2', {
+        feedbackAt: now - 52,
+        resultAt: now - 53,
+        rating: '0',
+      }),
+      // a2: paid + ratings [1, 1] -> 2/2 positive.
+      ratedJob(a2, customer, 'job-a2-paid', {
+        feedbackAt: now - 15,
+        resultAt: now - 16,
         status: 'payment-completed',
         txSignature: 'sig-a2',
-        jobEventId: jobA2,
       }),
-      makeFeedbackEvent(customer, a2.publicKey, { createdAt: now - 60, rating: '1' }),
-      makeFeedbackEvent(customer, a2.publicKey, { createdAt: now - 61, rating: '1' }),
+      ratedJob(a2, customer, 'job-a2-r0', {
+        feedbackAt: now - 60,
+        resultAt: now - 61,
+        rating: '1',
+      }),
+      ratedJob(a2, customer, 'job-a2-r1', {
+        feedbackAt: now - 61,
+        resultAt: now - 62,
+        rating: '1',
+      }),
     ];
-    const results = [
-      makeResultEvent(a1, { createdAt: now - 11, jobEventId: jobA1 }),
-      makeResultEvent(a2, { createdAt: now - 16, jobEventId: jobA2 }),
-    ];
+    const feedbacks = jobs.map((job) => job.feedback);
+    const results = jobs.map((job) => job.result);
 
     const pool = setupRoutedPool({
       capabilityEvents: [cap1, cap2],
@@ -704,30 +763,34 @@ describe('DiscoveryService.fetchAgents ranking', () => {
       }),
     );
 
-    const jobFresh = 'job-fresh';
-    const jobStale = 'job-stale';
-    const feedbacks = [
-      // fresh: paid 30s ago, no ratings
-      makeFeedbackEvent(customer, aFresh.publicKey, {
-        createdAt: now - 30,
+    const jobs = [
+      // fresh: paid 30s ago, no ratings.
+      ratedJob(aFresh, customer, 'job-fresh', {
+        feedbackAt: now - 30,
+        resultAt: now - 31,
         status: 'payment-completed',
         txSignature: 'sig-fresh',
-        jobEventId: jobFresh,
       }),
-      // stale: paid 10 minutes ago, perfect rating
-      makeFeedbackEvent(customer, aStale.publicKey, {
-        createdAt: now - 600,
+      // stale: paid 10 minutes ago, perfect rating (2/2).
+      ratedJob(aStale, customer, 'job-stale-paid', {
+        feedbackAt: now - 600,
+        resultAt: now - 601,
         status: 'payment-completed',
         txSignature: 'sig-stale',
-        jobEventId: jobStale,
       }),
-      makeFeedbackEvent(customer, aStale.publicKey, { createdAt: now - 601, rating: '1' }),
-      makeFeedbackEvent(customer, aStale.publicKey, { createdAt: now - 602, rating: '1' }),
+      ratedJob(aStale, customer, 'job-stale-r0', {
+        feedbackAt: now - 601,
+        resultAt: now - 602,
+        rating: '1',
+      }),
+      ratedJob(aStale, customer, 'job-stale-r1', {
+        feedbackAt: now - 602,
+        resultAt: now - 603,
+        rating: '1',
+      }),
     ];
-    const results = [
-      makeResultEvent(aFresh, { createdAt: now - 31, jobEventId: jobFresh }),
-      makeResultEvent(aStale, { createdAt: now - 601, jobEventId: jobStale }),
-    ];
+    const feedbacks = jobs.map((job) => job.feedback);
+    const results = jobs.map((job) => job.result);
 
     const pool = setupRoutedPool({
       capabilityEvents: [capFresh, capStale],
@@ -784,7 +847,13 @@ describe('DiscoveryService.fetchAgents ranking', () => {
         jobEventId: jobPaid,
       }),
     ];
-    const results = [makeResultEvent(aPaid, { createdAt: now - 201, jobEventId: jobPaid })];
+    const results = [
+      makeResultEvent(aPaid, {
+        createdAt: now - 201,
+        jobEventId: jobPaid,
+        customerPubkey: customer.publicKey,
+      }),
+    ];
 
     const pool = setupRoutedPool({
       capabilityEvents: [capPaid, capColdNew, capColdOld],
@@ -817,17 +886,30 @@ describe('DiscoveryService.fetchAgents ranking', () => {
         payment: { chain: 'solana', network: 'devnet', address: SOL_ADDRESS_A },
       }),
     );
-    // Customer authors all feedback events tagging the agent.
-    const feedbacks = [
-      makeFeedbackEvent(customer, agent.publicKey, { createdAt: now - 10, rating: '1' }),
-      makeFeedbackEvent(customer, agent.publicKey, { createdAt: now - 20, rating: '1' }),
-      makeFeedbackEvent(customer, agent.publicKey, { createdAt: now - 30, rating: '0' }),
+    // Each rating is tied to a delivered job whose result is addressed to the
+    // customer (`p` tag); only customer-authored ratings on delivered jobs count.
+    const jobs = [
+      ratedJob(agent, customer, 'job-r0', {
+        feedbackAt: now - 10,
+        resultAt: now - 11,
+        rating: '1',
+      }),
+      ratedJob(agent, customer, 'job-r1', {
+        feedbackAt: now - 20,
+        resultAt: now - 21,
+        rating: '1',
+      }),
+      ratedJob(agent, customer, 'job-r2', {
+        feedbackAt: now - 30,
+        resultAt: now - 31,
+        rating: '0',
+      }),
     ];
 
     const pool = setupRoutedPool({
       capabilityEvents: [cap],
-      resultEvents: [],
-      feedbackEvents: feedbacks,
+      resultEvents: jobs.map((job) => job.result),
+      feedbackEvents: jobs.map((job) => job.feedback),
     });
 
     const svc = new DiscoveryService(pool as any);
@@ -924,7 +1006,11 @@ describe('DiscoveryService.fetchAgents ranking', () => {
       }),
     ];
     const results = [
-      makeResultEvent(verifiedAgent, { createdAt: now - 601, jobEventId: jobVerified }),
+      makeResultEvent(verifiedAgent, {
+        createdAt: now - 601,
+        jobEventId: jobVerified,
+        customerPubkey: customer.publicKey,
+      }),
     ];
 
     const pool = setupRoutedPool({

--- a/packages/sdk/tests/quick-verify.test.ts
+++ b/packages/sdk/tests/quick-verify.test.ts
@@ -65,7 +65,7 @@ describe('verifyJobPaymentQuick', () => {
     }));
 
     const result = await verifyJobPaymentQuick(rpc, 'sig1', recipient);
-    expect(result.verified).toBe(true);
+    expect(result.receivedFunds).toBe(true);
     expect(result.txSignature).toBe('sig1');
   });
 
@@ -87,8 +87,8 @@ describe('verifyJobPaymentQuick', () => {
     const first = await verifyJobPaymentQuick(rpc, 'cached-sig', recipient);
     const second = await verifyJobPaymentQuick(rpc, 'cached-sig', recipient);
 
-    expect(first.verified).toBe(true);
-    expect(second.verified).toBe(true);
+    expect(first.receivedFunds).toBe(true);
+    expect(second.receivedFunds).toBe(true);
     expect(getTx).toHaveBeenCalledTimes(1);
   });
 
@@ -97,7 +97,7 @@ describe('verifyJobPaymentQuick', () => {
     const rpc = createMockRpc(() => ({ send: () => Promise.resolve(null) }));
 
     const result = await verifyJobPaymentQuick(rpc, 'missing-sig', recipient);
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('not_found');
   });
 
@@ -117,7 +117,7 @@ describe('verifyJobPaymentQuick', () => {
     }));
 
     const result = await verifyJobPaymentQuick(rpc, 'sig-other', recipient);
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('recipient_mismatch');
   });
 
@@ -137,7 +137,7 @@ describe('verifyJobPaymentQuick', () => {
     }));
 
     const result = await verifyJobPaymentQuick(rpc, 'sig-failed', recipient);
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('tx_failed');
   });
 
@@ -148,7 +148,7 @@ describe('verifyJobPaymentQuick', () => {
     }));
 
     const result = await verifyJobPaymentQuick(rpc, 'sig-throw', recipient);
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('rpc_error');
   });
 
@@ -158,21 +158,21 @@ describe('verifyJobPaymentQuick', () => {
       'sig-bad-rpc',
       makeAddress(),
     );
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('rpc_error');
   });
 
   it('rejects empty signature with invalid_input', async () => {
     const rpc = createMockRpc(() => ({ send: () => Promise.resolve(null) }));
     const result = await verifyJobPaymentQuick(rpc, '', makeAddress());
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('invalid_input');
   });
 
   it('rejects malformed recipient with invalid_input', async () => {
     const rpc = createMockRpc(() => ({ send: () => Promise.resolve(null) }));
     const result = await verifyJobPaymentQuick(rpc, 'sig', 'not-a-real-address' as Address);
-    expect(result.verified).toBe(false);
+    expect(result.receivedFunds).toBe(false);
     expect(result.reason).toBe('invalid_input');
   });
 
@@ -202,7 +202,7 @@ describe('verifyJobPaymentQuick', () => {
     }));
 
     const result = await verifyJobPaymentQuick(rpc, 'spl-sig', recipient);
-    expect(result.verified).toBe(true);
+    expect(result.receivedFunds).toBe(true);
   });
 
   it('negative cache expires after TTL so second call hits RPC again', async () => {
@@ -225,18 +225,18 @@ describe('verifyJobPaymentQuick', () => {
       const rpc = createMockRpc(getTx);
 
       const first = await verifyJobPaymentQuick(rpc, 'expiring-sig', recipient);
-      expect(first.verified).toBe(false);
+      expect(first.receivedFunds).toBe(false);
       expect(first.reason).toBe('not_found');
 
       // Within TTL: cached negative
       const second = await verifyJobPaymentQuick(rpc, 'expiring-sig', recipient);
-      expect(second.verified).toBe(false);
+      expect(second.receivedFunds).toBe(false);
       expect(getTx).toHaveBeenCalledTimes(1);
 
       // Past TTL: re-queries
       vi.advanceTimersByTime(61_000);
       const third = await verifyJobPaymentQuick(rpc, 'expiring-sig', recipient);
-      expect(third.verified).toBe(true);
+      expect(third.receivedFunds).toBe(true);
       expect(getTx).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();

--- a/packages/sdk/tests/skills.test.ts
+++ b/packages/sdk/tests/skills.test.ts
@@ -673,12 +673,19 @@ script: ./fail.sh
     chmodSync(scriptPath, 0o755);
 
     const skills = loadSkillsFromDir(tmpDir);
-    await expect(
-      skills[0]!.execute(
+    let thrown: unknown;
+    try {
+      await skills[0]!.execute(
         { data: '', inputType: 'text', tags: ['fail'], jobId: 'j3' },
         { agentName: 't', agentDescription: '' },
-      ),
-    ).rejects.toThrow(/exit 7.*boom/);
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    // The thrown message is generic and customer-safe ("script failed (exit 7)");
+    // the raw stderr ("boom") lives only on the operator-side `detail` field.
+    expect((thrown as Error).message).toMatch(/script failed \(exit 7\)/);
+    expect((thrown as { detail?: string }).detail).toContain('boom');
   });
 
   it('loads a dynamic-script skill and execute pipes stdin to stdout', async () => {


### PR DESCRIPTION
Security hardening pass (deepsec):

Payments & verification
- BuyContext: refuse cards with no/unknown recipient or non-Solana chain, bound the charge to the advertised price, and reject feedback-vs-signed amount mismatches (bait-and-switch protection)
- discovery: count ratings / paid timestamps only from the job's actual customer (result `p` tag) on delivered jobs, deduped per (customer, job)
- quick-verify: rename `verified` -> `receivedFunds` (received funds is not proof of a valid job payment), cap the cache, drop expired negatives

Untrusted input & secret leakage
- sanitize: full-text windowed injection scan, wider dangerous-Unicode set, stricter base64 detection
- job-input: block sensitive files (.secrets/.env/ssh/keypair/~/.elisym/proc), confine reads to cwd unless allow_outside_cwd, neutralize git config attack vectors (diff.external/hooks/fsmonitor) and validate the diff ref
- mcp tools: sanitize attacker-controlled card fields and wrap responses in the untrusted boundary; redact key/secret shapes in LLM-facing error messages
- cli: allowlist customer-safe error messages (raw stderr stays operator-side), redact API keys embedded in RPC URL path/query, strip LLM API keys from tool subprocess env, reject tool args beginning with "-"
- skills/loader: contain image_file to the skill dir; exact-integer SOL parsing

Reliability & correctness
- customer-history: fix write-lock map leak (compare against wrapped promise)
- agent: switch_agent loads the target before tearing down the old agent
- http: keep timeout/abort armed across the response body read
- wallet: best-effort post-payment balance so an RPC hiccup can't report a committed payment as failed; bigint balances end-to-end
- ledger: owner-only perms on ledger files/dir
- utils: formatSolShort handles negative amounts

CI
- least-privilege workflow permissions, SHA-pinned actions, SHA-256 checksum verification for mcp-publisher

Releases
- @elisym/sdk 0.22.0 -> 0.23.0, @elisym/mcp 0.13.0 -> 0.14.0 (+ server.json), @elisym/cli 0.19.0 -> 0.20.0; cli/mcp sdk dep bumped to ~0.23.0