### PR TITLE
sdk: add the dedicated elisym relay to RELAYS

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/app",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "clean": "rm -rf build dist"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.25.3",
+    "@elisym/sdk": "~0.25.5",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/token": "~0.5.0",
     "@solana/kit": "~6.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/cli",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "CLI agent runner for elisym - provider mode, skills, crash recovery",
   "keywords": [
     "ai-agents",
@@ -44,7 +44,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.25.3",
+    "@elisym/sdk": "~0.25.5",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/system": "~0.12.0",
     "@solana-program/token": "~0.5.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/mcp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "MCP server for elisym - AI agent discovery, jobs, and payments",
   "keywords": [
     "ai-agents",
@@ -56,7 +56,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.25.3",
+    "@elisym/sdk": "~0.25.5",
     "@modelcontextprotocol/sdk": "~1.28.0",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/system": "~0.12.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.16.0",
+  "version": "0.16.1",
   "websiteUrl": "https://www.elisym.network",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@elisym/mcp",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/sdk",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "description": "TypeScript SDK for elisym - AI agent discovery, marketplace, and payments on Nostr",
   "keywords": [
     "ai-agents",

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -1,6 +1,8 @@
 import type { Address } from '@solana/kit';
 
 export const RELAYS = [
+  // Dedicated elisym relay (self-hosted) first, public relays as fallback.
+  'wss://relay.elisym.network',
   'wss://relay.damus.io',
   'wss://nos.lol',
   'wss://relay.nostr.band',


### PR DESCRIPTION
Adds our self-hosted Nostr relay to the SDK's default `RELAYS` and ships it as a patch release.

## What
- **`wss://relay.elisym.network`** added as the **primary** relay (first in `RELAYS`), ahead of the public relays (damus / nos.lol / nostr.band / primal / snort), which stay as fallbacks.
- **Version bumps** (manual, all packages together - matching the repo convention):
  - `@elisym/sdk` 0.25.4 -> **0.25.5**
  - `@elisym/mcp` 0.16.0 -> **0.16.1** (dep `@elisym/sdk` `~0.25.5`; `server.json` synced)
  - `@elisym/cli` 0.22.4 -> **0.22.5** (dep `@elisym/sdk` `~0.25.5`)
  - `@elisym/app` 0.7.3 -> **0.7.4** (dep `@elisym/sdk` `~0.25.5`)

## Why
The dedicated relay is live (deployed in `elisym-infra`: `scsibug/nostr-rs-relay` behind Caddy + Let's Encrypt). Wiring it into `RELAYS` is what makes the SDK actually publish/subscribe through our own relay, so elisym discovery / marketplace / policy events no longer depend solely on third-party relays. Roadmap: "Own Nostr relay - dedicated elisym relay".

The relay is open to any pubkey (the marketplace needs arbitrary customer/provider keys) and accepts all elisym kinds; generic social spam is bounded server-side by a kind blacklist + rate cap.

## Verified
- NIP-11 over real TLS: `name: "elisym relay"`, `version: 0.10.0`, `limitation.restricted_writes: false`.
- Full publish -> query roundtrip against `wss://relay.elisym.network` passes.
- `bun qa` green (build + test + typecheck + lint + format + spell).