### PR TITLE
Fix release Docker build (copy all workspace manifests, v2) + bump mcp 0.20.2 / cli 0.25.2

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,16 +1,14 @@
-# Pin bun to the lockfile's version (same as CI). A floating `1` tag drifts to
-# newer patches whose resolver rejects the committed lockfile under --frozen-lockfile.
+# syntax=docker/dockerfile:1
+# Pin bun to the lockfile / CI version (1.3.11) for reproducible installs.
 FROM oven/bun:1.3.11-slim AS base
 
 WORKDIR /app
 
-# Install root workspace files
+# Root manifests + every workspace package.json. `--parents` keeps the
+# packages/<name>/ layout and globs all members, so bun's frozen install always
+# sees the full workspace and a new package needs no Dockerfile edit.
 COPY package.json bun.lock turbo.json ./
-COPY packages/config-client/package.json packages/config-client/package.json
-COPY packages/sdk/package.json packages/sdk/package.json
-COPY packages/mcp/package.json packages/mcp/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/app/package.json packages/app/package.json
+COPY --parents packages/*/package.json ./
 
 # Install production dependencies
 RUN bun install --frozen-lockfile --production

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/cli",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "CLI agent runner for elisym - provider mode, skills, crash recovery",
   "keywords": [
     "ai-agents",

--- a/packages/mcp/Dockerfile
+++ b/packages/mcp/Dockerfile
@@ -1,16 +1,14 @@
-# Pin bun to the lockfile's version (same as CI). A floating `1` tag drifts to
-# newer patches whose resolver rejects the committed lockfile under --frozen-lockfile.
+# syntax=docker/dockerfile:1
+# Pin bun to the lockfile / CI version (1.3.11) for reproducible installs.
 FROM oven/bun:1.3.11-slim AS base
 
 WORKDIR /app
 
-# Install root workspace files
+# Root manifests + every workspace package.json. `--parents` keeps the
+# packages/<name>/ layout and globs all members, so bun's frozen install always
+# sees the full workspace and a new package needs no Dockerfile edit.
 COPY package.json bun.lock turbo.json ./
-COPY packages/config-client/package.json packages/config-client/package.json
-COPY packages/sdk/package.json packages/sdk/package.json
-COPY packages/mcp/package.json packages/mcp/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/app/package.json packages/app/package.json
+COPY --parents packages/*/package.json ./
 
 # Install production dependencies
 RUN bun install --frozen-lockfile --production

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/mcp",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "MCP server for elisym - AI agent discovery, jobs, and payments",
   "keywords": [
     "ai-agents",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.20.1",
+  "version": "0.20.2",
   "websiteUrl": "https://www.elisym.network",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@elisym/mcp",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Re-fix of #78: that PR was merged from a stale branch head that still had the broken Dockerfile, so mcp 0.20.1 / cli 0.25.1 published to npm without Docker images.

## Fix
- `COPY --parents packages/*/package.json ./` in both Dockerfiles - copies all 6 workspace manifests (the missing `packages/docs` was the root cause of the frozen-lockfile failure), robust against new packages. Verified with a local `docker build` (--parents copies all manifests, frozen production install passes).
- Bump mcp 0.20.1 -> 0.20.2 and cli 0.25.1 -> 0.25.2 (server.json synced) so the release rebuilds the images on the corrected Dockerfile. sdk/app unchanged.