### PR TITLE
My Jobs: global job history with an unseen-result badge

### DIFF
--- a/packages/app/app/components/Header.tsx
+++ b/packages/app/app/components/Header.tsx
@@ -7,6 +7,7 @@ import { track } from '~/lib/analytics';
 import { cn } from '~/lib/cn';
 import { ConnectMenu } from './ConnectMenu';
 import { truncateMiddle } from './CopyRow';
+import { JobsNavLink } from './JobsNavLink';
 import { MarbleAvatar } from './MarbleAvatar';
 import { MessagesNavLink } from './MessagesNavLink';
 import { ProviderKeyDialog } from './ProviderKeyDialog';
@@ -231,9 +232,11 @@ export function Header() {
               <span className="hidden sm:inline">Run AI Agent</span>
             </a>
 
-            {/* Messages are gated behind a wallet OR provider session;
-                unmounting also stops the live DM subscription for
-                signed-out visitors. */}
+            {/* Messages and Jobs are gated behind a wallet OR provider
+                session; unmounting also stops the live DM subscription for
+                signed-out visitors. The /jobs page itself stays reachable
+                by URL without a wallet - it just has no badge. */}
+            {(address || providerSession) && <JobsNavLink dark={dark} />}
             {(address || providerSession) && <MessagesNavLink dark={dark} />}
 
             {accountNode}

--- a/packages/app/app/components/JobsNavLink.tsx
+++ b/packages/app/app/components/JobsNavLink.tsx
@@ -1,0 +1,50 @@
+import { useWallet } from '@solana/wallet-adapter-react';
+import { Link } from 'wouter';
+import { useUnseenJobsCount } from '~/hooks/useJobHistory';
+import { cn } from '~/lib/cn';
+
+interface Props {
+  dark: boolean;
+}
+
+/**
+ * Header entry point for the global job history (/jobs). The badge counts
+ * `unseen` terminal flips - results that landed while the user was not
+ * looking - from the shared job-history store.
+ */
+export function JobsNavLink({ dark }: Props) {
+  const { publicKey } = useWallet();
+  const unseen = useUnseenJobsCount(publicKey?.toBase58() ?? '');
+
+  return (
+    <Link
+      to="/jobs"
+      aria-label={unseen > 0 ? `Jobs, ${unseen} new results` : 'Jobs'}
+      className={cn(
+        'relative inline-flex shrink-0 items-center justify-center rounded-12 border p-8 no-underline transition-colors sm:px-10',
+        dark
+          ? 'border-white/8 bg-white/8 text-white hover:bg-white/10'
+          : 'border-black/15 bg-transparent text-surface-dark hover:bg-black/4',
+      )}
+    >
+      <svg
+        aria-hidden
+        className="size-16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+        <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+      </svg>
+      {unseen > 0 && (
+        <span className="absolute -top-6 -right-6 inline-flex h-16 min-w-16 items-center justify-center rounded-full bg-accent px-4 text-[10px] font-semibold text-white">
+          {unseen > 99 ? '99+' : unseen}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/packages/app/app/contexts/BuyContext.tsx
+++ b/packages/app/app/contexts/BuyContext.tsx
@@ -12,6 +12,7 @@ import {
   LIMITS,
   MAX_PROOF_TTL_SECS,
   mintDelegationNonce,
+  assetKey,
   resolveKnownAsset,
   SolanaPaymentStrategy,
   toDTag,
@@ -100,6 +101,24 @@ const RESUMABLE_PENDING_STATUSES = new Set(['pending', 'payment-completed']);
  * (not recoverable) while a maybe-landed failure becomes resumable 'pending'.
  */
 class PaymentRevertedError extends Error {}
+
+/**
+ * The unseen-badge in-view criterion: a terminal flip stamps `unseen` only
+ * when the user is NOT looking at this agent's page - which requires the tab
+ * to be visible, not merely on the right path (a result landing in a hidden
+ * tab was not seen; the Chat tab's clear effect wipes the flag the moment
+ * the tab becomes visible again). Read live inside the callback - never
+ * decide against the effect-closure `session`, which survives route
+ * navigation by design and would suppress the stamp for the most recent job
+ * forever.
+ */
+function agentPageInView(agentPubkey: string): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    document.visibilityState === 'visible' &&
+    window.location.pathname === `/agent/${agentPubkey}`
+  );
+}
 
 async function retryWithBackoff<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -286,7 +305,7 @@ export function BuyProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const [, setLocation] = useLocation();
   const wallet = publicKey?.toBase58() ?? '';
-  const { jobs, saveJob, updateJob } = useJobHistory({ wallet });
+  const { jobs, saveJob, updateJob, flipJob } = useJobHistory({ wallet });
 
   const [session, setSession] = useState<ActiveBuySession | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
@@ -349,6 +368,7 @@ export function BuyProvider({ children }: { children: ReactNode }) {
       // here keeps writing to the wallet that was connected at click.
       const snapshotSaveJob = saveJob;
       const snapshotUpdateJob = updateJob;
+      const snapshotFlipJob = flipJob;
 
       const cardName = card.name;
       const sessionMatches = (s: ActiveBuySession | null): s is ActiveBuySession =>
@@ -626,7 +646,10 @@ export function BuyProvider({ children }: { children: ReactNode }) {
                 return;
               }
               if (!publicKey) {
-                toast.error('Wallet disconnected - reconnect and retry', { id: toastId });
+                // Dismiss-then-toast, not a same-id swap - see the sonner
+                // spinner-stick note in onError below.
+                toast.dismiss(toastId);
+                toast.error('Wallet disconnected - reconnect and retry');
                 setSession((prev) => (sessionMatches(prev) ? { ...prev, buying: false } : prev));
                 // Terminal, unpaid exit: the job will never be paid, so the
                 // pending entry gains the Retry affordance now instead of
@@ -751,8 +774,24 @@ export function BuyProvider({ children }: { children: ReactNode }) {
                 // If confirmTransaction throws (an RPC hiccup after the tx landed) or the
                 // confirmation publish below exhausts its retries, the catch marks the job
                 // 'error', but this merge keeps the signature so a successful payment is
-                // never discarded and can be reconciled from history.
-                snapshotUpdateJob(jobEventId, { txHash: signature });
+                // never discarded and can be reconciled from history. The charge fields
+                // ride the same write: this is the only point where a charge is certain
+                // AND `paymentRequest` is in scope - a resumable-paid job recovered by
+                // the poller never reaches the post-confirmation update, so stamping
+                // there would leave it amount-less forever.
+                const chargedAsset = resolveKnownAsset(
+                  paymentRequest.asset?.chain ?? 'solana',
+                  paymentRequest.asset?.token ?? 'sol',
+                  paymentRequest.asset?.mint,
+                );
+                snapshotUpdateJob(jobEventId, {
+                  txHash: signature,
+                  // Always resolvable in practice - an unknown asset cannot pass
+                  // validatePaymentRequest above; the guard is honest typing.
+                  ...(chargedAsset !== undefined
+                    ? { paymentAmount: paymentRequest.amount, assetKey: assetKey(chargedAsset) }
+                    : {}),
+                });
                 // Same rule for the thread entry: a paid `pending` entry (txHash
                 // present) is exempt from unpaid-aging and trimming - money was
                 // sent, the state must stay visible.
@@ -783,9 +822,16 @@ export function BuyProvider({ children }: { children: ReactNode }) {
                   ),
                 );
 
+                // `paymentAmount` is NOT written here: the broadcast point above is
+                // the only amount writer (the feedback-advertised `amount` may be
+                // undefined/0 and would clobber the real charge). If a provider
+                // error feedback flipped the row terminal mid-confirm, the store's
+                // sticky-terminal guard keeps `error` and only the txHash lands -
+                // accepted: the job did fail as far as anyone knows, and should the
+                // provider crash-recover and complete it later, the /jobs merge
+                // folds the relay-side success over the local row for display.
                 snapshotUpdateJob(jobEventId, {
                   status: 'payment-completed',
-                  paymentAmount: amount,
                   txHash: signature,
                 });
                 paidLocally = true;
@@ -817,11 +863,22 @@ export function BuyProvider({ children }: { children: ReactNode }) {
                 // A confirmed on-chain revert moved no funds, so drop the signature we
                 // optimistically persisted before confirmation - otherwise it could later
                 // ride a rating as false payment proof for a payment that never landed.
-                snapshotUpdateJob(
+                // The charge fields stamped at broadcast go with it: a reverted job
+                // must not display a charge. The cleanup rides `updateJob`, NOT the
+                // flip: a provider error feedback can flip this row terminal while
+                // confirmTransaction is in flight, and flipTerminal's guard would then
+                // drop the whole patch, leaving the reverted signature persisted.
+                if (err instanceof PaymentRevertedError) {
+                  snapshotUpdateJob(jobEventId, {
+                    txHash: undefined,
+                    paymentAmount: undefined,
+                    assetKey: undefined,
+                  });
+                }
+                snapshotFlipJob(
                   jobEventId,
-                  err instanceof PaymentRevertedError
-                    ? { status: 'error', txHash: undefined }
-                    : { status: 'error' },
+                  { status: 'error' },
+                  { stampUnseen: !agentPageInView(agentPubkey) },
                 );
                 // Terminal payment failure (never broadcast, or reverted with no
                 // funds moved): the thread entry gains the Retry affordance. The
@@ -861,11 +918,19 @@ export function BuyProvider({ children }: { children: ReactNode }) {
               // delegation remains the truth).
               const delegatedTxHash =
                 delegatedPayment !== undefined && paymentTx !== undefined ? paymentTx : undefined;
-              snapshotUpdateJob(jobEventId, {
-                status: 'completed',
-                result,
-                ...(delegatedTxHash !== undefined ? { txHash: delegatedTxHash } : {}),
-              });
+              const alreadyOnAgentPage = agentPageInView(agentPubkey);
+              if (delegatedTxHash !== undefined) {
+                // Unconditional stamp: if the /jobs merge in another tab or the
+                // poller already flipped this row terminal, flipTerminal's guard
+                // would drop the whole patch and the settlement signature would
+                // never reach wallet history (the rating's payment proof).
+                snapshotUpdateJob(jobEventId, { txHash: delegatedTxHash });
+              }
+              snapshotFlipJob(
+                jobEventId,
+                { status: 'completed', result },
+                { stampUnseen: !alreadyOnAgentPage },
+              );
               if (delegatedTxHash !== undefined) {
                 void recordEntryTxHash(agentPubkey, jobEventId, delegatedTxHash);
               }
@@ -892,9 +957,10 @@ export function BuyProvider({ children }: { children: ReactNode }) {
               );
               cleanupRef.current = null;
               const agentPath = `/agent/${agentPubkey}`;
-              const alreadyOnAgentPage = window.location.pathname === agentPath;
+              // Dismiss-then-toast, not a same-id swap - see the sonner
+              // spinner-stick note in onError below.
+              toast.dismiss(toastId);
               toast.success(`Result received from ${agentName}`, {
-                id: toastId,
                 // Override the global 1500ms default so the user has time to
                 // notice the result and click through to the provider's page.
                 duration: 8000,
@@ -941,7 +1007,11 @@ export function BuyProvider({ children }: { children: ReactNode }) {
             },
 
             onError: (errMsg: string) => {
-              snapshotUpdateJob(jobEventId, { status: 'error' });
+              snapshotFlipJob(
+                jobEventId,
+                { status: 'error' },
+                { stampUnseen: !agentPageInView(agentPubkey) },
+              );
               // A provider error feedback (incl. "session busy") becomes an
               // ordinary failed bubble with Retry. If the provider completes
               // the job later anyway (crash-recovery re-execution), hydration
@@ -986,7 +1056,11 @@ export function BuyProvider({ children }: { children: ReactNode }) {
                   toast('Payment sent - still confirming; check job history shortly.');
                   return;
                 }
-                snapshotUpdateJob(jobEventId, { status: 'error' });
+                snapshotFlipJob(
+                  jobEventId,
+                  { status: 'error' },
+                  { stampUnseen: !agentPageInView(agentPubkey) },
+                );
                 // Unpaid timeout is terminal for the thread entry (the design's
                 // aging rule, applied eagerly while the tab is still open). A
                 // paid timeout above stays `pending` - money was sent.
@@ -1049,6 +1123,7 @@ export function BuyProvider({ children }: { children: ReactNode }) {
       signMessage,
       saveJob,
       updateJob,
+      flipJob,
       queryClient,
       setLocation,
     ],
@@ -1136,7 +1211,11 @@ export function BuyProvider({ children }: { children: ReactNode }) {
             // Wallet job history only - deliberately NO thread-store write here:
             // a poller-recovered result reaches the thread via the Chat tab's
             // hydration/reconcile (the stated eventual-consistency window).
-            updateJob(job.jobEventId, { status: 'completed', result });
+            flipJob(
+              job.jobEventId,
+              { status: 'completed', result },
+              { stampUnseen: !agentPageInView(job.agentPubkey) },
+            );
             // The job may have settled by a delegated pull that reduced the
             // allowance; the poller has no per-job rail marker, so drop the
             // cached read unconditionally for the connected wallet.
@@ -1169,7 +1248,7 @@ export function BuyProvider({ children }: { children: ReactNode }) {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [wallet, idCtx.identity, client, updateJob, queryClient]);
+  }, [wallet, idCtx.identity, client, flipJob, queryClient]);
 
   const rate = useCallback(
     async (positive: boolean) => {

--- a/packages/app/app/hooks/useJobHistory.ts
+++ b/packages/app/app/hooks/useJobHistory.ts
@@ -1,67 +1,43 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
+import {
+  flipTerminal as storeFlipTerminal,
+  readJobs,
+  saveJob as storeSaveJob,
+  subscribeJobHistory,
+  unseenJobsCount,
+  updateJob as storeUpdateJob,
+  type StoredJob,
+} from '~/lib/jobHistory';
 
-export interface StoredJob {
-  jobEventId: string;
-  agentPubkey: string;
-  agentName: string;
-  agentPicture?: string;
-  capability: string;
-  status: string;
-  paymentAmount?: number;
-  txHash?: string;
-  result?: string;
-  createdAt: number;
-}
+export type { StoredJob } from '~/lib/jobHistory';
 
-const STORAGE_KEY = 'elisym:job-history';
-
-function loadJobs(wallet: string): StoredJob[] {
-  try {
-    const raw = localStorage.getItem(`${STORAGE_KEY}:${wallet}`);
-    return raw ? (JSON.parse(raw) as StoredJob[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function persistJobs(wallet: string, jobs: StoredJob[]) {
-  localStorage.setItem(`${STORAGE_KEY}:${wallet}`, JSON.stringify(jobs));
-}
-
+/**
+ * Thin `useSyncExternalStore` view over the shared job-history store
+ * (`~/lib/jobHistory`). The callbacks close over `wallet`, so a caller that
+ * snapshots them (BuyContext's mid-job closures) keeps writing under the
+ * wallet the job was bought with even if the wallet disconnects mid-job.
+ */
 export function useJobHistory({ wallet }: { wallet: string }) {
-  const [jobs, setJobs] = useState<StoredJob[]>(() => (wallet ? loadJobs(wallet) : []));
+  const jobs = useSyncExternalStore(subscribeJobHistory, () => readJobs(wallet));
 
-  useEffect(() => {
-    setJobs(wallet ? loadJobs(wallet) : []);
-  }, [wallet]);
-
-  const saveJob = useCallback(
-    (job: StoredJob) => {
-      if (!wallet) {
-        return;
-      }
-      setJobs((prev) => {
-        const next = [job, ...prev.filter((j) => j.jobEventId !== job.jobEventId)];
-        persistJobs(wallet, next);
-        return next;
-      });
-    },
-    [wallet],
-  );
+  const saveJob = useCallback((job: StoredJob) => storeSaveJob(wallet, job), [wallet]);
 
   const updateJob = useCallback(
-    (jobEventId: string, patch: Partial<StoredJob>) => {
-      if (!wallet) {
-        return;
-      }
-      setJobs((prev) => {
-        const next = prev.map((j) => (j.jobEventId === jobEventId ? { ...j, ...patch } : j));
-        persistJobs(wallet, next);
-        return next;
-      });
-    },
+    (jobEventId: string, patch: Partial<StoredJob>) => storeUpdateJob(wallet, jobEventId, patch),
     [wallet],
   );
 
-  return { jobs, saveJob, updateJob };
+  /** Terminal flip with the store-side freshly-read-row guard (plan decision 4/5). */
+  const flipJob = useCallback(
+    (jobEventId: string, patch: Partial<StoredJob>, opts: { stampUnseen: boolean }) =>
+      storeFlipTerminal(wallet, jobEventId, patch, opts),
+    [wallet],
+  );
+
+  return { jobs, saveJob, updateJob, flipJob };
+}
+
+/** Live `unseen` badge count for the header (number snapshots are stable). */
+export function useUnseenJobsCount(wallet: string): number {
+  return useSyncExternalStore(subscribeJobHistory, () => unseenJobsCount(wallet));
 }

--- a/packages/app/app/hooks/usePageVisible.ts
+++ b/packages/app/app/hooks/usePageVisible.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from 'react';
+
+function subscribeVisibility(onChange: () => void): () => void {
+  document.addEventListener('visibilitychange', onChange);
+  return () => document.removeEventListener('visibilitychange', onChange);
+}
+
+function isDocumentVisible(): boolean {
+  return document.visibilityState === 'visible';
+}
+
+/**
+ * Whether the document is currently visible. The unseen-clear effects key on
+ * this: "the page stays open" must mean "the user can see it", or a background
+ * tab parked on /jobs (or an agent's Chat tab) would eat every badge the
+ * active tab stamps, via the cross-tab storage event.
+ */
+export function usePageVisible(): boolean {
+  return useSyncExternalStore(subscribeVisibility, isDocumentVisible);
+}

--- a/packages/app/app/lib/explorer.ts
+++ b/packages/app/app/lib/explorer.ts
@@ -1,0 +1,10 @@
+import { SOLANA_CLUSTER } from './cluster';
+
+/**
+ * Explorer URL for a transaction signature, cluster-aware via the app's
+ * single cluster switch (no hardcoded cluster strings at call sites).
+ */
+export function explorerTxUrl(txHash: string): string {
+  const suffix = SOLANA_CLUSTER === 'mainnet' ? '' : `?cluster=${SOLANA_CLUSTER}`;
+  return `https://explorer.solana.com/tx/${txHash}${suffix}`;
+}

--- a/packages/app/app/lib/jobHistory.ts
+++ b/packages/app/app/lib/jobHistory.ts
@@ -1,0 +1,306 @@
+/**
+ * Wallet-keyed job history (`elisym:job-history:<wallet>`) as a shared module
+ * store behind the readCursors listener/version idiom, so BuyContext's writes
+ * reach every subscriber (nav badge, /jobs page, Chat tab) reactively.
+ *
+ * Writes are read-modify-write PATCHES against localStorage keyed by
+ * `jobEventId`, never a persist of a caller's whole in-memory array: under two
+ * tabs a full-snapshot write lets a stale tab clobber the other's flips
+ * (revert a `completed` row to `pending`, re-stamp `unseen` after a clear).
+ * A patch spread keeps explicitly-`undefined` keys, and JSON serialization
+ * drops them, so `{ txHash: undefined }` clears the field on persist (the
+ * PaymentRevertedError branch relies on exactly that).
+ *
+ * Accepted residual: two tabs' concurrent read-modify-write can lose an
+ * `unseen` stamp - and, in the same millisecond window, a just-stamped
+ * delegated settlement txHash under a concurrent flip from another tab.
+ * Statuses self-heal on the next poll tick, a missed badge is cosmetic, and
+ * for the txHash the on-chain delegation record remains the truth (the
+ * thread entry keeps its own copy) - so this store stays synchronous
+ * instead of adopting the async `navigator.locks` path chatSession needs.
+ */
+
+export const JOB_HISTORY_KEY_PREFIX = 'elisym:job-history:';
+
+const TERMINAL_STATUSES = new Set(['completed', 'error']);
+
+export interface StoredJob {
+  jobEventId: string;
+  agentPubkey: string;
+  agentName: string;
+  agentPicture?: string;
+  capability: string;
+  status: string;
+  /** Raw subunits of `assetKey`'s asset - stamped together at tx broadcast. */
+  paymentAmount?: number;
+  /** SDK assetKey of the charged asset; absent on legacy and unpaid rows. */
+  assetKey?: string;
+  txHash?: string;
+  result?: string;
+  createdAt: number;
+  /** Epoch ms of the terminal flip. */
+  completedAt?: number;
+  /** Result landed while the user was not looking; cleared by /jobs and the Chat tab. */
+  unseen?: boolean;
+}
+
+export interface JobHistoryStorageAdapter {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface JobHistoryStore {
+  readJobs(wallet: string): StoredJob[];
+  saveJob(wallet: string, job: StoredJob): void;
+  updateJob(wallet: string, jobEventId: string, patch: Partial<StoredJob>): void;
+  flipTerminal(
+    wallet: string,
+    jobEventId: string,
+    patch: Partial<StoredJob>,
+    opts: { stampUnseen: boolean },
+  ): void;
+  clearUnseen(wallet: string, agentPubkey?: string): void;
+  unseenCount(wallet: string): number;
+  handleExternalChange(key: string): void;
+  subscribe(listener: () => void): () => void;
+  version(): number;
+}
+
+const browserStorage: JobHistoryStorageAdapter = {
+  getItem: (key) => {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem: (key, value) => {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Quota/private-mode failures degrade to per-tab state - harmless.
+    }
+  },
+};
+
+const EMPTY_JOBS: StoredJob[] = [];
+
+function storageKey(wallet: string): string {
+  return `${JOB_HISTORY_KEY_PREFIX}${wallet}`;
+}
+
+/** Tolerant parse (the readCursors idiom): a corrupt value reads as empty. */
+function parseJobs(raw: string | null): StoredJob[] {
+  if (raw === null) {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter(
+    (entry): entry is StoredJob =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      'jobEventId' in entry &&
+      typeof (entry as { jobEventId: unknown }).jobEventId === 'string',
+  );
+}
+
+export function isTerminalJobStatus(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+export function createJobHistoryStore(
+  storage: JobHistoryStorageAdapter = browserStorage,
+): JobHistoryStore {
+  const listeners = new Set<() => void>();
+  let storeVersion = 0;
+  /** getSnapshot stability: one cached array per wallet, invalidated by version. */
+  const snapshots = new Map<string, { version: number; jobs: StoredJob[] }>();
+
+  function notify(): void {
+    storeVersion += 1;
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function readRaw(wallet: string): StoredJob[] {
+    return parseJobs(storage.getItem(storageKey(wallet)));
+  }
+
+  function persist(wallet: string, jobs: StoredJob[]): void {
+    storage.setItem(storageKey(wallet), JSON.stringify(jobs));
+    notify();
+  }
+
+  function readJobs(wallet: string): StoredJob[] {
+    if (!wallet) {
+      return EMPTY_JOBS;
+    }
+    const cached = snapshots.get(wallet);
+    if (cached && cached.version === storeVersion) {
+      return cached.jobs;
+    }
+    const jobs = readRaw(wallet);
+    snapshots.set(wallet, { version: storeVersion, jobs });
+    return jobs;
+  }
+
+  function saveJob(wallet: string, job: StoredJob): void {
+    if (!wallet) {
+      return;
+    }
+    const current = readRaw(wallet);
+    persist(wallet, [job, ...current.filter((existing) => existing.jobEventId !== job.jobEventId)]);
+  }
+
+  function updateJob(wallet: string, jobEventId: string, patch: Partial<StoredJob>): void {
+    if (!wallet) {
+      return;
+    }
+    const current = readRaw(wallet);
+    const row = current.find((existing) => existing.jobEventId === jobEventId);
+    if (!row) {
+      // Never create an absent row, and a no-op must not bump the version.
+      return;
+    }
+    // Terminal status is sticky: a late non-terminal writer (an onTimeout or
+    // resumable-payment `pending` racing the poller or another tab's flip)
+    // must not revert a `completed`/`error` row - the poller skips rows with
+    // results, so the row would show "In progress" forever. Non-status keys
+    // still apply: the revert cleanup and txHash stamps rely on that.
+    const { status: patchStatus, ...restPatch } = patch;
+    const demotesTerminal =
+      patchStatus !== undefined &&
+      isTerminalJobStatus(row.status) &&
+      !isTerminalJobStatus(patchStatus);
+    const effectivePatch = demotesTerminal ? restPatch : patch;
+    if (Object.keys(effectivePatch).length === 0) {
+      return;
+    }
+    persist(
+      wallet,
+      current.map((existing) =>
+        existing.jobEventId === jobEventId ? { ...existing, ...effectivePatch } : existing,
+      ),
+    );
+  }
+
+  function flipTerminal(
+    wallet: string,
+    jobEventId: string,
+    patch: Partial<StoredJob>,
+    opts: { stampUnseen: boolean },
+  ): void {
+    if (!wallet) {
+      return;
+    }
+    const current = readRaw(wallet);
+    const row = current.find((existing) => existing.jobEventId === jobEventId);
+    // Decided against the freshly-read row: if another tab (or an earlier
+    // path) already flipped this job, re-applying the flip would resurrect
+    // an `unseen` flag the /jobs page may have cleared since.
+    if (!row || isTerminalJobStatus(row.status)) {
+      return;
+    }
+    persist(
+      wallet,
+      current.map((existing) =>
+        existing.jobEventId === jobEventId
+          ? {
+              ...existing,
+              ...patch,
+              completedAt: Date.now(),
+              ...(opts.stampUnseen ? { unseen: true } : {}),
+            }
+          : existing,
+      ),
+    );
+  }
+
+  function clearUnseen(wallet: string, agentPubkey?: string): void {
+    if (!wallet) {
+      return;
+    }
+    const current = readRaw(wallet);
+    const matches = (job: StoredJob): boolean =>
+      job.unseen === true && (agentPubkey === undefined || job.agentPubkey === agentPubkey);
+    if (!current.some(matches)) {
+      // No-op clears must not write: the clear-while-mounted effects key on
+      // the version this write would bump - writing anyway would loop.
+      return;
+    }
+    persist(
+      wallet,
+      current.map((job) => (matches(job) ? { ...job, unseen: undefined } : job)),
+    );
+  }
+
+  function unseenCount(wallet: string): number {
+    let count = 0;
+    for (const job of readJobs(wallet)) {
+      if (job.unseen === true) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  function handleExternalChange(key: string): void {
+    if (key.startsWith(JOB_HISTORY_KEY_PREFIX)) {
+      notify();
+    }
+  }
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  function version(): number {
+    return storeVersion;
+  }
+
+  return {
+    readJobs,
+    saveJob,
+    updateJob,
+    flipTerminal,
+    clearUnseen,
+    unseenCount,
+    handleExternalChange,
+    subscribe,
+    version,
+  };
+}
+
+const defaultStore = createJobHistoryStore();
+
+if (typeof window !== 'undefined') {
+  // Cross-tab reactivity: another tab's write arrives as a `storage` event;
+  // bumping the version re-derives every subscriber's snapshot.
+  window.addEventListener('storage', (event) => {
+    if (event.key !== null) {
+      defaultStore.handleExternalChange(event.key);
+    }
+  });
+}
+
+export const readJobs = defaultStore.readJobs;
+export const saveJob = defaultStore.saveJob;
+export const updateJob = defaultStore.updateJob;
+export const flipTerminal = defaultStore.flipTerminal;
+export const clearUnseen = defaultStore.clearUnseen;
+export const unseenJobsCount = defaultStore.unseenCount;
+/** Subscription surface for useSyncExternalStore. */
+export const subscribeJobHistory = defaultStore.subscribe;
+export const jobHistoryVersion = defaultStore.version;

--- a/packages/app/app/root.tsx
+++ b/packages/app/app/root.tsx
@@ -10,6 +10,7 @@ import { Providers } from '~/components/Providers';
 import { TermsModal } from '~/components/TermsModal';
 import AgentPage from '~/routes/Agent/Agent';
 import Home from '~/routes/Home/Home';
+import JobsPage from '~/routes/Jobs/Jobs';
 import MessagesPage from '~/routes/Messages/Messages';
 import Terms from '~/routes/Terms/Terms';
 
@@ -34,6 +35,7 @@ export function App() {
               <Route path="/agent/:pubkey">{(params) => <AgentPage key={params?.pubkey} />}</Route>
               <Route path="/messages" component={MessagesPage} />
               <Route path="/messages/:pubkey" component={MessagesPage} />
+              <Route path="/jobs" component={JobsPage} />
               <Route path="/terms" component={Terms} />
               <Route>
                 <div className="flex min-h-[60vh] items-center justify-center">

--- a/packages/app/app/routes/Agent/ChatEntry.tsx
+++ b/packages/app/app/routes/Agent/ChatEntry.tsx
@@ -103,7 +103,7 @@ export function ChatEntry({
     // max-w-[85%] resolve against its own content width, collapsing short
     // results into a one-word-per-line sliver.
     assistantBubble = (
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-8">
         <ChatBubble side="assistant" onClick={onOpen}>
           <p className="m-0 line-clamp-6 break-words whitespace-pre-wrap">
             {resultPreview || 'Result received'}
@@ -159,7 +159,7 @@ export function ChatEntry({
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-8">
       {(entry.prompt || promptFileChip) && (
         <ChatBubble side="user" onClick={completed ? onOpen : undefined}>
           {entry.prompt && (

--- a/packages/app/app/routes/Agent/ChatTab.tsx
+++ b/packages/app/app/routes/Agent/ChatTab.tsx
@@ -1,10 +1,12 @@
 import { type CapabilityCard, toDTag } from '@elisym/sdk';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useLocation, useSearch } from 'wouter';
 import { useBuy } from '~/contexts/BuyContext';
 import { useElisymClient } from '~/hooks/useElisymClient';
 import { useIdentity } from '~/hooks/useIdentity';
 import { useJobHistory } from '~/hooks/useJobHistory';
+import { usePageVisible } from '~/hooks/usePageVisible';
 import type { PingStatus } from '~/hooks/usePingAgent';
 import { track } from '~/lib/analytics';
 import {
@@ -16,6 +18,7 @@ import {
 } from '~/lib/chatSession';
 import type { ChatThreadEntry } from '~/lib/chatThread';
 import { SOLANA_CLUSTER } from '~/lib/cluster';
+import { clearUnseen, jobHistoryVersion, subscribeJobHistory } from '~/lib/jobHistory';
 import { cacheGet, cacheSet } from '~/lib/localCache';
 import { ArtifactModal } from './ArtifactModal';
 import { ChatComposer } from './ChatComposer';
@@ -116,7 +119,24 @@ export function ChatTab({
   // a rating can carry the payment proof for the future indexer (the entry's
   // own txHash is NOT used - a reverted tx must never ride a rating as proof).
   const { publicKey: walletPublicKey } = useWallet();
-  const { jobs: walletJobs } = useJobHistory({ wallet: walletPublicKey?.toBase58() ?? '' });
+  const wallet = walletPublicKey?.toBase58() ?? '';
+  const { jobs: walletJobs } = useJobHistory({ wallet });
+
+  // The unseen-badge's second clear site: viewing this agent's Chat tab
+  // clears its rows' flags on mount and while mounted AND visible - the
+  // result toast's "View" action lands here, and without this the badge
+  // would stay lit after the user has read the result. The visibility gate
+  // keeps a background tab left on this Chat tab from eating flags stamped
+  // by the active tab (storage events land here too). Keyed on (wallet,
+  // store version, visibility); the store's no-op-write guard breaks the
+  // version self-loop.
+  const chatTabVisible = usePageVisible();
+  const jobHistoryStoreVersion = useSyncExternalStore(subscribeJobHistory, jobHistoryVersion);
+  useEffect(() => {
+    if (wallet && chatTabVisible) {
+      clearUnseen(wallet, agentPubkey);
+    }
+  }, [wallet, agentPubkey, jobHistoryStoreVersion, chatTabVisible]);
   const txHashByJobId = useMemo(() => {
     const map = new Map<string, string>();
     for (const job of walletJobs) {
@@ -262,6 +282,82 @@ export function ChatTab({
   // exists (the composer would continue it, so the view must show the draft -
   // never the newest chat over an invisible session), else the newest chat,
   // else the draft.
+  const selectSessionChat = useCallback(
+    async (item: ChatListItem, sessionId: string): Promise<boolean> => {
+      // Make the clicked conversation the active session FIRST - the view must
+      // never switch while the composer would still send into another session.
+      // A refusal (a sibling tab's send is resolving, or its crashed token is
+      // not yet stale) keeps the current chat; the click can be retried.
+      const selected = await selectSession(identityPubkey, agentPubkey, {
+        sessionId,
+        ts: item.lastTs,
+      });
+      if (!selected) {
+        return false;
+      }
+      setManualKey(item.key);
+      // Bind the composer to the chat's last used capability.
+      const lastEntry = item.entries[item.entries.length - 1];
+      const cardIndex = cards.findIndex(
+        (candidate) => toDTag(candidate.name) === lastEntry?.capability,
+      );
+      if (cardIndex !== -1) {
+        onSelectIndex(cardIndex);
+      }
+      return true;
+    },
+    [identityPubkey, agentPubkey, cards, onSelectIndex],
+  );
+
+  // /jobs deep-link: `?job=<jobEventId>` selects the chat containing that
+  // entry and hands the id to the thread for the focus scroll. Applied only
+  // once the hydrated thread actually contains the entry (hydration may
+  // still be running - the effect re-runs on `entries` changes), then the
+  // param is stripped (the `?tab=history` precedent in Agent.tsx) so
+  // back-nav and manual chat switching are not re-forced. A session chat is
+  // ACTIVATED via selectSessionChat, not merely displayed - the composer
+  // sends into the stored active session, so showing chat B over active
+  // session A would route the user's reply into another conversation's
+  // context. A selection refusal leaves the param in place; the effect
+  // retries on the next entries/store change.
+  const search = useSearch();
+  const [, setLocation] = useLocation();
+  const [focusJobId, setFocusJobId] = useState<string | null>(null);
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const jobParam = params.get('job');
+    if (!jobParam) {
+      return;
+    }
+    const entry = entries.find((candidate) => candidate.jobEventId === jobParam);
+    if (!entry) {
+      return;
+    }
+    let cancelled = false;
+    const applyDeepLink = async () => {
+      const item = items.find((candidate) => candidate.key === chatKeyOf(entry));
+      if (item === undefined) {
+        return;
+      }
+      if (item.kind === 'session' && item.sessionId !== undefined) {
+        const switched = await selectSessionChat(item, item.sessionId);
+        if (!switched || cancelled) {
+          return;
+        }
+      } else {
+        setManualKey(item.key);
+      }
+      setFocusJobId(jobParam);
+      params.delete('job');
+      const remaining = params.toString();
+      setLocation(`/agent/${agentPubkey}${remaining ? `?${remaining}` : ''}`, { replace: true });
+    };
+    void applyDeepLink();
+    return () => {
+      cancelled = true;
+    };
+  }, [search, entries, items, agentPubkey, selectSessionChat, setLocation]);
+
   let selectedKey = NEW_CHAT_KEY;
   const manualValid =
     manualKey !== null &&
@@ -299,6 +395,9 @@ export function ChatTab({
 
   // Follow a live send once per job id (the messenger pattern: jump to the
   // chat you just messaged) - covers draft sends, retries, and one-shots.
+  // A send also releases the deep-link focus: the thread holds its viewport
+  // at the focused entry while the focus is set, and the user's own message
+  // must scroll normally.
   const followedJobRef = useRef<string | null>(null);
   useEffect(() => {
     if (liveJobEventId === null || followedJobRef.current === liveJobEventId) {
@@ -307,37 +406,18 @@ export function ChatTab({
     const entry = entries.find((candidate) => candidate.jobEventId === liveJobEventId);
     if (entry !== undefined) {
       followedJobRef.current = liveJobEventId;
+      setFocusJobId(null);
       setManualKey(chatKeyOf(entry));
     }
   }, [liveJobEventId, entries]);
-
-  async function selectSessionChat(item: ChatListItem, sessionId: string) {
-    // Make the clicked conversation the active session FIRST - the view must
-    // never switch while the composer would still send into another session.
-    // A refusal (a sibling tab's send is resolving, or its crashed token is
-    // not yet stale) keeps the current chat; the click can be retried.
-    const selected = await selectSession(identityPubkey, agentPubkey, {
-      sessionId,
-      ts: item.lastTs,
-    });
-    if (!selected) {
-      return;
-    }
-    setManualKey(item.key);
-    // Bind the composer to the chat's last used capability.
-    const lastEntry = item.entries[item.entries.length - 1];
-    const cardIndex = cards.findIndex(
-      (candidate) => toDTag(candidate.name) === lastEntry?.capability,
-    );
-    if (cardIndex !== -1) {
-      onSelectIndex(cardIndex);
-    }
-  }
 
   function handleSelectChat(item: ChatListItem) {
     if (buying) {
       return;
     }
+    // A manual chat switch releases the deep-link focus - the thread must
+    // resume its normal newest-message scroll in the newly selected chat.
+    setFocusJobId(null);
     if (item.kind === 'session' && item.sessionId !== undefined) {
       void selectSessionChat(item, item.sessionId);
       return;
@@ -349,6 +429,7 @@ export function ChatTab({
     if (buying) {
       return;
     }
+    setFocusJobId(null);
     setManualKey(NEW_CHAT_KEY);
   }
 
@@ -404,6 +485,7 @@ export function ChatTab({
           onOpen={(entry) => setOpenEntryId(entry.jobEventId)}
           onSelectCardIndex={onSelectIndex}
           send={send}
+          focusJobEventId={focusJobId}
         />
 
         {readOnly ? (

--- a/packages/app/app/routes/Agent/ChatThread.tsx
+++ b/packages/app/app/routes/Agent/ChatThread.tsx
@@ -34,6 +34,8 @@ interface Props {
   onOpen: (entry: ChatThreadEntry) => void;
   onSelectCardIndex: (index: number) => void;
   send: ChatSend;
+  /** /jobs deep-link target: scroll this entry into view once. */
+  focusJobEventId?: string | null;
 }
 
 interface ThreadItem {
@@ -121,18 +123,42 @@ export function ChatThread({
   onOpen,
   onSelectCardIndex,
   send,
+  focusJobEventId,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const lastEntryId = entries.length > 0 ? entries[entries.length - 1]?.jobEventId : undefined;
 
   // Auto-scroll to the newest message (the messenger pattern) whenever the
-  // thread grows or the newest entry changes state.
+  // thread grows or the newest entry changes state - suspended while a
+  // deep-link focus is active, or hydration finishing after the focus scroll
+  // would yank the viewport away from the entry the user came to read. The
+  // parent releases the focus on a manual chat switch or a live send, which
+  // resumes the normal scroll.
   useEffect(() => {
+    if (focusJobEventId) {
+      return;
+    }
     const el = scrollRef.current;
     if (el) {
       el.scrollTop = el.scrollHeight;
     }
-  }, [entries.length, lastEntryId]);
+  }, [entries.length, lastEntryId, focusJobEventId]);
+
+  // /jobs deep-link: scroll the focused entry into view. Handled once per
+  // id - the scroll must not re-fire on every entries change. Deliberately
+  // scroll-only: an entry highlight was tried and removed by design.
+  const handledFocusRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!focusJobEventId || handledFocusRef.current === focusJobEventId) {
+      return;
+    }
+    const target = scrollRef.current?.querySelector(`[data-job-id="${focusJobEventId}"]`);
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    handledFocusRef.current = focusJobEventId;
+    target.scrollIntoView({ block: 'center' });
+  }, [focusJobEventId, entries]);
 
   if (loading && entries.length === 0) {
     return <ChatThreadSkeleton />;
@@ -154,7 +180,7 @@ export function ChatThread({
   const items = buildThreadItems(entries);
 
   return (
-    <div ref={scrollRef} className="flex max-h-[65vh] flex-col gap-8 overflow-y-auto p-2 sm:p-6">
+    <div ref={scrollRef} className="flex max-h-[65vh] flex-col gap-16 overflow-y-auto p-2 sm:p-6">
       {items.map(({ entry, dayLabel, sessionDivider }) => (
         <div key={entry.jobEventId} className="flex flex-col gap-8">
           {dayLabel && (
@@ -173,29 +199,31 @@ export function ChatThread({
               <span className="h-px flex-1 bg-black/6" />
             </div>
           )}
-          <ChatEntry
-            entry={entry}
-            agentPubkey={agentPubkey}
-            liveStatus={entry.jobEventId === liveJobEventId ? liveStatus : null}
-            rated={ratedIds.has(entry.jobEventId)}
-            canRate={canRate && entry.capability !== ''}
-            onRate={(positive) => onRate(entry, positive)}
-            onOpen={() => onOpen(entry)}
-            retryNode={
-              entry.status === 'failed' ? (
-                <ChatRetryButton
-                  entry={entry}
-                  cards={cards}
-                  agentPubkey={agentPubkey}
-                  pingStatus={pingStatus}
-                  buying={buying}
-                  entries={allEntries}
-                  onSelectCardIndex={onSelectCardIndex}
-                  send={send}
-                />
-              ) : undefined
-            }
-          />
+          <div data-job-id={entry.jobEventId}>
+            <ChatEntry
+              entry={entry}
+              agentPubkey={agentPubkey}
+              liveStatus={entry.jobEventId === liveJobEventId ? liveStatus : null}
+              rated={ratedIds.has(entry.jobEventId)}
+              canRate={canRate && entry.capability !== ''}
+              onRate={(positive) => onRate(entry, positive)}
+              onOpen={() => onOpen(entry)}
+              retryNode={
+                entry.status === 'failed' ? (
+                  <ChatRetryButton
+                    entry={entry}
+                    cards={cards}
+                    agentPubkey={agentPubkey}
+                    pingStatus={pingStatus}
+                    buying={buying}
+                    entries={allEntries}
+                    onSelectCardIndex={onSelectCardIndex}
+                    send={send}
+                  />
+                ) : undefined
+              }
+            />
+          </div>
         </div>
       ))}
     </div>

--- a/packages/app/app/routes/Agent/FileResultCard.tsx
+++ b/packages/app/app/routes/Agent/FileResultCard.tsx
@@ -33,7 +33,12 @@ const ICON_PATHS: Record<MediaKind, string> = {
 export function FileResultCard({ attachment, providerPubkey }: Props) {
   const { client } = useElisymClient();
   const idCtx = useIdentity();
-  const [loading, setLoading] = useState(false);
+  // The label swaps to "Loading…" only on the button that initiated the
+  // fetch (the auto-preview counts as 'preview') - there is one underlying
+  // fetch, so BOTH buttons disable, but two simultaneous "Loading…" labels
+  // read as a broken card.
+  const [loadingAction, setLoadingAction] = useState<'preview' | 'download' | null>(null);
+  const loading = loadingAction !== null;
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const loadedRef = useRef<Loaded | null>(null);
   const unmountedRef = useRef(false);
@@ -44,12 +49,13 @@ export function FileResultCard({ attachment, providerPubkey }: Props) {
   // path passes the small cap as `maxBytes` too - otherwise a provider that lies about
   // the size could make opening the modal silently fetch+decrypt up to 100 MiB.
   async function load(
+    action: 'preview' | 'download',
     maxBytes: number = LIMITS.MAX_BLOSSOM_ENCRYPTED_BYTES,
   ): Promise<Loaded | null> {
     if (loadedRef.current) {
       return loadedRef.current;
     }
-    setLoading(true);
+    setLoadingAction(action);
     try {
       const out = await fetchEncryptedFileOutput({
         attachment,
@@ -78,12 +84,12 @@ export function FileResultCard({ attachment, providerPubkey }: Props) {
       toast.error(err instanceof Error ? err.message : 'Failed to fetch the file');
       return null;
     } finally {
-      setLoading(false);
+      setLoadingAction(null);
     }
   }
 
   async function handleDownload() {
-    const data = await load();
+    const data = await load('download');
     if (data) {
       saveDecryptedFile(data.bytes, data.name, data.mime);
     }
@@ -95,7 +101,7 @@ export function FileResultCard({ attachment, providerPubkey }: Props) {
     // fetch would see `unmounted` and bail, leaving the auto-preview blank.
     unmountedRef.current = false;
     if (kind === 'image' && attachment.size <= AUTO_PREVIEW_MAX_BYTES) {
-      void load(AUTO_PREVIEW_MAX_BYTES);
+      void load('preview', AUTO_PREVIEW_MAX_BYTES);
     }
     return () => {
       unmountedRef.current = true;
@@ -146,11 +152,11 @@ export function FileResultCard({ attachment, providerPubkey }: Props) {
         <div className="flex shrink-0 items-center gap-8">
           {showPreviewButton && (
             <button
-              onClick={() => void load()}
+              onClick={() => void load('preview')}
               disabled={loading}
               className="cursor-pointer rounded-xl border border-black/10 bg-surface px-12 py-8 text-xs font-medium text-text transition-colors hover:bg-black/[0.04] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {loading ? 'Loading…' : 'Preview'}
+              {loadingAction === 'preview' ? 'Loading…' : 'Preview'}
             </button>
           )}
           <button
@@ -158,7 +164,7 @@ export function FileResultCard({ attachment, providerPubkey }: Props) {
             disabled={loading}
             className="cursor-pointer rounded-xl border-none bg-surface-dark px-14 py-8 text-xs font-semibold text-white transition-colors hover:bg-[#2a2a2e] disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {loading ? 'Loading…' : 'Download'}
+            {loadingAction === 'download' ? 'Loading…' : 'Download'}
           </button>
         </div>
       </div>

--- a/packages/app/app/routes/Jobs/JobRow.tsx
+++ b/packages/app/app/routes/Jobs/JobRow.tsx
@@ -1,0 +1,128 @@
+import { assetByKey, timeAgo, truncateKey } from '@elisym/sdk';
+import { nip19 } from 'nostr-tools';
+import { useState } from 'react';
+import { Link } from 'wouter';
+import { MarbleAvatar } from '~/components/MarbleAvatar';
+import { useCachedAgentProfile } from '~/hooks/useCachedAgentProfile';
+import { cn } from '~/lib/cn';
+import { explorerTxUrl } from '~/lib/explorer';
+import { formatDecimal } from '~/lib/formatPrice';
+import { JobStatusChip } from './JobStatusChip';
+import type { JobRowData } from './lib/rows';
+
+interface Props {
+  row: JobRowData;
+  /** "Landed while you were away" tint, held by the page for the visit (the
+   * store's `unseen` flag itself is cleared right after first paint). */
+  highlighted: boolean;
+}
+
+/**
+ * A compact index row: status and metadata only. The whole card is a
+ * stretched link to the agent's Chat tab (which hydrates and reconciles the
+ * result in conversation context); the tx link stacks above the overlay so
+ * it stays independently clickable. A relay-only row without a provider
+ * pubkey gets no link at all - `/agent/` resolves to the not-found page.
+ */
+export function JobRow({ row, highlighted }: Props) {
+  const agentPubkey = row.agentPubkey ?? '';
+  const profile = useCachedAgentProfile(agentPubkey);
+  const [imgError, setImgError] = useState(false);
+
+  const chatPath = `/agent/${agentPubkey}?tab=history&job=${row.jobEventId}`;
+  const displayName =
+    row.agentName?.trim() ||
+    profile?.name?.trim() ||
+    (agentPubkey ? truncateKey(nip19.npubEncode(agentPubkey), 6) : 'Unknown provider');
+  const picture = row.agentPicture ?? profile?.picture;
+
+  let amountLabel: string | undefined;
+  if (row.assetKey && row.paymentAmount) {
+    const asset = assetByKey(row.assetKey);
+    if (asset) {
+      amountLabel = `${formatDecimal(row.paymentAmount, asset.decimals)} ${asset.symbol}`;
+    }
+  }
+
+  return (
+    <li
+      className={cn(
+        'relative flex items-center gap-12 border-b border-black/5 px-14 py-12 transition-colors last:border-b-0',
+        agentPubkey && 'hover:bg-black/3',
+        highlighted && 'bg-accent/4',
+      )}
+    >
+      {agentPubkey && (
+        <Link
+          to={chatPath}
+          aria-label={`Open chat with ${displayName}`}
+          className="absolute inset-0"
+        />
+      )}
+      <div className="flex size-36 shrink-0 items-center justify-center overflow-hidden rounded-full">
+        {picture && !imgError ? (
+          <img
+            src={picture}
+            alt={displayName}
+            loading="lazy"
+            referrerPolicy="no-referrer"
+            className="size-full object-cover"
+            onError={() => setImgError(true)}
+          />
+        ) : (
+          <MarbleAvatar name={agentPubkey || row.jobEventId} size={36} />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-8">
+          <span
+            className={cn(
+              'truncate text-xs font-medium text-text',
+              row.agentName || profile?.name ? 'font-sans' : 'font-mono',
+            )}
+          >
+            {displayName}
+          </span>
+          <JobStatusChip status={row.status} />
+          {row.source === 'nostr-only' && (
+            <span className="shrink-0 rounded-8 border border-black/8 px-6 py-1 text-[10px] text-text-2">
+              from relays
+            </span>
+          )}
+          <span className="ml-auto shrink-0 text-[10px] text-text-2 opacity-60">
+            {timeAgo(row.timestampSecs)}
+          </span>
+        </div>
+        <div className="mt-2 flex items-center gap-8 text-xs text-text-2">
+          {row.capability && <span className="truncate">{row.capability}</span>}
+          {amountLabel && <span className="shrink-0 font-medium">{amountLabel}</span>}
+          {row.txHash && (
+            <a
+              href={explorerTxUrl(row.txHash)}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="relative z-10 shrink-0 font-mono text-[10px] text-accent no-underline hover:underline"
+            >
+              tx:{row.txHash.slice(0, 8)}…
+            </a>
+          )}
+        </div>
+      </div>
+      {agentPubkey && (
+        <span aria-hidden className="flex size-28 shrink-0 items-center justify-center text-text-2">
+          <svg
+            className="size-14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </span>
+      )}
+    </li>
+  );
+}

--- a/packages/app/app/routes/Jobs/JobStatusChip.tsx
+++ b/packages/app/app/routes/Jobs/JobStatusChip.tsx
@@ -1,0 +1,34 @@
+import { cn } from '~/lib/cn';
+
+interface Props {
+  status: string;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  completed: 'bg-feedback-positive-bg text-feedback-positive',
+  error: 'bg-feedback-negative-bg text-feedback-negative',
+  pending: 'bg-surface-2 text-text-2',
+  'payment-completed': 'bg-surface-2 text-text-2',
+  submitted: 'bg-surface-2 text-text-2',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  completed: 'Completed',
+  error: 'Failed',
+  pending: 'In progress',
+  'payment-completed': 'Paid',
+  submitted: 'Submitted',
+};
+
+export function JobStatusChip({ status }: Props) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center rounded-8 px-8 py-2 text-[10px] font-semibold',
+        STATUS_STYLES[status] ?? 'bg-surface-2 text-text-2',
+      )}
+    >
+      {STATUS_LABELS[status] ?? status}
+    </span>
+  );
+}

--- a/packages/app/app/routes/Jobs/Jobs.tsx
+++ b/packages/app/app/routes/Jobs/Jobs.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { usePageVisible } from '~/hooks/usePageVisible';
+import { cn } from '~/lib/cn';
+import { clearUnseen, jobHistoryVersion, readJobs, subscribeJobHistory } from '~/lib/jobHistory';
+import { JobRow } from './JobRow';
+import { useJobsMerge } from './useJobsMerge';
+
+/** Rows rendered per "page" - the full merged list stays in memory, only the
+ * DOM is capped so a large history cannot make the page unusable. */
+const PAGE_SIZE = 50;
+
+export default function JobsPage() {
+  const { rows, wallet, merged, isFetching, isError, refetch } = useJobsMerge();
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  // Decision 4 clear site (a): every `unseen` flag is cleared on mount and
+  // kept clear while the page stays VISIBLE - keyed on (wallet, store
+  // version, visibility) so a poller flip landing mid-visit, a wallet
+  // switch, or a return to a background tab is covered. The visibility
+  // gate matters: a background tab parked here receives the active tab's
+  // writes as storage events and would otherwise clear flags nobody saw.
+  // The store's no-op-write guard breaks the version self-loop. The flagged
+  // ids are recorded BEFORE the clear so the "landed while you were away"
+  // tint survives the visit instead of vanishing one frame after paint.
+  const pageVisible = usePageVisible();
+  // One flat set for the mount's lifetime: job event ids are globally unique
+  // nostr event ids, so entries surviving a wallet switch cannot mis-tint
+  // another wallet's rows.
+  const highlightedIdsRef = useRef<Set<string>>(new Set());
+  const storeVersion = useSyncExternalStore(subscribeJobHistory, jobHistoryVersion);
+  useEffect(() => {
+    if (!wallet || !pageVisible) {
+      return;
+    }
+    for (const job of readJobs(wallet)) {
+      if (job.unseen === true) {
+        highlightedIdsRef.current.add(job.jobEventId);
+      }
+    }
+    clearUnseen(wallet);
+  }, [wallet, storeVersion, pageVisible]);
+
+  let syncLabel = 'Synced from relays - older events may have expired.';
+  if (isFetching) {
+    syncLabel = 'Syncing from relays…';
+  } else if (isError) {
+    syncLabel = 'Relay sync failed - showing local history only.';
+  } else if (!merged) {
+    syncLabel = 'Showing local history.';
+  }
+
+  const visibleRows = rows.slice(0, visibleCount);
+  const remaining = rows.length - visibleRows.length;
+
+  return (
+    <div id="light-content" className="pt-12 pb-48 sm:pt-16 sm:pb-64">
+      <div className="mx-auto max-w-3xl px-12 sm:px-24">
+        <div className="flex items-center justify-between gap-12">
+          <h1 className="text-lg font-bold sm:text-xl">My Jobs</h1>
+          <button
+            type="button"
+            onClick={refetch}
+            disabled={isFetching}
+            className="inline-flex h-28 btn items-center justify-center gap-6 btn-outline px-10 text-[11px]"
+          >
+            <svg
+              aria-hidden
+              className={cn('size-12', isFetching && 'animate-spin')}
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+              <polyline points="21 3 21 9 15 9" />
+            </svg>
+            Refresh
+          </button>
+        </div>
+        <p className="mt-4 mb-16 text-xs text-text-2">
+          Jobs you submitted, across every provider. {syncLabel}
+        </p>
+        {rows.length > 0 ? (
+          <>
+            <ul className="overflow-hidden rounded-2xl border border-black/7 bg-surface">
+              {visibleRows.map((row) => (
+                <JobRow
+                  key={row.jobEventId}
+                  row={row}
+                  highlighted={row.unseen || highlightedIdsRef.current.has(row.jobEventId)}
+                />
+              ))}
+            </ul>
+            {remaining > 0 && (
+              <div className="mt-12 flex justify-center">
+                <button
+                  type="button"
+                  onClick={() => setVisibleCount((count) => count + PAGE_SIZE)}
+                  className="inline-flex h-28 btn items-center justify-center btn-outline px-12 text-[11px]"
+                >
+                  Show more ({remaining})
+                </button>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="flex flex-col items-center gap-8 rounded-2xl border border-black/7 bg-surface px-16 py-48 text-center">
+            <p className="text-sm font-medium text-text">No jobs yet</p>
+            <p className="text-xs text-text-2">
+              Hire an agent from the home page - every job you submit shows up here.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/app/app/routes/Jobs/lib/rows.ts
+++ b/packages/app/app/routes/Jobs/lib/rows.ts
@@ -1,0 +1,133 @@
+import { assetKey, resolveKnownAsset, type Job, type JobStatus } from '@elisym/sdk';
+import { isTerminalJobStatus, type StoredJob } from '~/lib/jobHistory';
+
+export type JobRowSource = 'local' | 'merged' | 'nostr-only';
+
+export interface JobRowData {
+  jobEventId: string;
+  source: JobRowSource;
+  agentPubkey?: string;
+  agentName?: string;
+  agentPicture?: string;
+  capability?: string;
+  /** Local status vocabulary (relay values folded via RELAY_STATUS_TO_LOCAL). */
+  status: string;
+  /** Raw subunits + SDK assetKey - present together or not at all (decision 8). */
+  paymentAmount?: number;
+  assetKey?: string;
+  txHash?: string;
+  /** Unix seconds (local `createdAt` ms are normalized). */
+  timestampSecs: number;
+  unseen: boolean;
+}
+
+/**
+ * Total mapping of the SDK `JobStatus` vocabulary into the local one the
+ * status chip renders - the `Record<JobStatus, _>` type keeps it total when
+ * the SDK grows a value.
+ */
+export const RELAY_STATUS_TO_LOCAL: Record<JobStatus, string> = {
+  success: 'completed',
+  error: 'error',
+  processing: 'pending',
+  'payment-required': 'submitted',
+  'payment-completed': 'payment-completed',
+  partial: 'pending',
+  unknown: 'submitted',
+};
+
+/**
+ * Merged-row status precedence, asymmetric by direction: relay `success`
+ * (it exists only when a result event was observed) wins over any local
+ * status; relay `error` (feedback-derived - the result event may simply have
+ * been missed or expired) wins only over a local NON-terminal status; a
+ * non-terminal relay status never overrides the local one (it would mask
+ * client-side terminal errors Nostr never sees).
+ */
+function mergedStatus(localStatus: string, relayStatus: JobStatus): string {
+  if (relayStatus === 'success') {
+    return 'completed';
+  }
+  if (relayStatus === 'error' && !isTerminalJobStatus(localStatus)) {
+    return 'error';
+  }
+  return localStatus;
+}
+
+/** Decision 8: an amount renders only when the asset is known alongside it. */
+function localAmountFields(local: StoredJob): Pick<JobRowData, 'paymentAmount' | 'assetKey'> {
+  if (
+    local.assetKey !== undefined &&
+    local.paymentAmount !== undefined &&
+    local.paymentAmount > 0
+  ) {
+    return { paymentAmount: local.paymentAmount, assetKey: local.assetKey };
+  }
+  return {};
+}
+
+/**
+ * Decision 8 for relay rows: `Job.asset` undefined is ambiguous between
+ * "native SOL" and "payment-required feedback not observed", so an amount
+ * renders only on an explicit, known asset.
+ */
+function relayAmountFields(job: Job): Pick<JobRowData, 'paymentAmount' | 'assetKey'> {
+  if (!job.asset || job.amount === undefined || job.amount <= 0) {
+    return {};
+  }
+  const known = resolveKnownAsset(job.asset.chain, job.asset.token, job.asset.mint);
+  if (!known) {
+    return {};
+  }
+  return { paymentAmount: job.amount, assetKey: assetKey(known) };
+}
+
+/**
+ * The /jobs page is an index, not a reader: rows carry status and metadata
+ * only - results are read on the agent's Chat tab, which hydrates and
+ * reconciles them from the relays in conversation context.
+ */
+export function buildJobRows(localJobs: StoredJob[], relayJobs: Job[]): JobRowData[] {
+  const relayById = new Map(relayJobs.map((job) => [job.eventId, job]));
+  const rows: JobRowData[] = [];
+
+  for (const local of localJobs) {
+    const relay = relayById.get(local.jobEventId);
+    rows.push({
+      jobEventId: local.jobEventId,
+      source: relay ? 'merged' : 'local',
+      agentPubkey: local.agentPubkey,
+      agentName: local.agentName,
+      agentPicture: local.agentPicture,
+      capability: local.capability,
+      status: relay ? mergedStatus(local.status, relay.status) : local.status,
+      ...localAmountFields(local),
+      txHash: local.txHash ?? relay?.txHash,
+      timestampSecs: Math.floor(local.createdAt / 1000),
+      unseen: local.unseen === true,
+    });
+  }
+
+  const localIds = new Set(localJobs.map((local) => local.jobEventId));
+  for (const relay of relayJobs) {
+    if (localIds.has(relay.eventId)) {
+      continue;
+    }
+    rows.push({
+      jobEventId: relay.eventId,
+      source: 'nostr-only',
+      agentPubkey: relay.agentPubkey,
+      capability: relay.capability,
+      status: RELAY_STATUS_TO_LOCAL[relay.status],
+      ...relayAmountFields(relay),
+      txHash: relay.txHash,
+      timestampSecs: relay.createdAt,
+      unseen: false,
+    });
+  }
+
+  return rows.sort(
+    (left, right) =>
+      right.timestampSecs - left.timestampSecs || (left.jobEventId < right.jobEventId ? -1 : 1),
+  );
+}

--- a/packages/app/app/routes/Jobs/useJobsMerge.ts
+++ b/packages/app/app/routes/Jobs/useJobsMerge.ts
@@ -1,0 +1,160 @@
+import type { ElisymClient, ElisymIdentity } from '@elisym/sdk';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+import { useElisymClient } from '~/hooks/useElisymClient';
+import { useIdentity } from '~/hooks/useIdentity';
+import { useJobHistory } from '~/hooks/useJobHistory';
+import { usePageVisible } from '~/hooks/usePageVisible';
+import { decodeResult, resultDisplay } from '~/lib/fileResult';
+import { isTerminalJobStatus, readJobs } from '~/lib/jobHistory';
+import { buildJobRows, type JobRowData } from './lib/rows';
+
+/** Relay merge window and request limit (plan decision 7). */
+const RELAY_WINDOW_SECS = 30 * 24 * 60 * 60;
+const RELAY_FETCH_LIMIT = 300;
+
+interface DecryptedJobResult {
+  content: string;
+  decryptionFailed: boolean;
+}
+
+interface RelaySide {
+  jobs: Awaited<ReturnType<ElisymClient['marketplace']['fetchRecentJobs']>>;
+  results: Map<string, DecryptedJobResult>;
+}
+
+/**
+ * Side-effect-free relay fetch: requests authored by this identity, plus a
+ * decrypted-results batch for LOCAL NON-TERMINAL rows only - the page never
+ * displays result content (that lives on the agent's Chat tab), the batch
+ * exists solely to flip stuck local rows (decision 2). Local rows are read
+ * fresh (non-reactively) here - the id set depends on them, but the query
+ * must not re-run on every store write.
+ */
+async function fetchRelaySide(
+  client: ElisymClient,
+  identity: ElisymIdentity,
+  wallet: string,
+): Promise<RelaySide> {
+  const identityPubkey = identity.publicKey;
+  const since = Math.floor(Date.now() / 1000) - RELAY_WINDOW_SECS;
+  const fetched = await client.marketplace.fetchRecentJobs(
+    undefined,
+    RELAY_FETCH_LIMIT,
+    since,
+    undefined,
+    identityPubkey,
+  );
+  // Relay-distrust verification (the MCP precedent): a relay ignoring the
+  // `authors` filter must not inject other customers' jobs.
+  const jobs = fetched.filter((job) => job.customer === identityPubkey);
+
+  // Local non-terminal rows are queried for results, independent of
+  // request-event retention on the relays (the `submitted`-forever free-job
+  // case has no resumable poller path) - but only within the same 30-day
+  // window: some rows can never turn terminal (an error feedback that landed
+  // while the tab was closed is not fetched here), and without the cutoff
+  // the id list would grow forever. Past the window the result has expired
+  // off the relays anyway, so querying it is futile. Bound to the local
+  // row's provider - an unbound id would accept a forged higher-created_at
+  // result.
+  const localCutoffMs = Date.now() - RELAY_WINDOW_SECS * 1000;
+  const providerByRequest = new Map<string, string>();
+  const resultIds: string[] = [];
+  for (const local of readJobs(wallet)) {
+    if (isTerminalJobStatus(local.status) || local.createdAt < localCutoffMs) {
+      continue;
+    }
+    resultIds.push(local.jobEventId);
+    providerByRequest.set(local.jobEventId, local.agentPubkey);
+  }
+
+  let results = new Map<string, DecryptedJobResult>();
+  if (resultIds.length > 0) {
+    const decrypted = await client.marketplace.queryJobResults(
+      identity,
+      resultIds,
+      undefined,
+      undefined,
+      providerByRequest,
+    );
+    results = new Map(
+      [...decrypted.entries()].map(([id, value]) => [
+        id,
+        { content: value.content, decryptionFailed: value.decryptionFailed },
+      ]),
+    );
+  }
+  return { jobs, results };
+}
+
+export function useJobsMerge(): {
+  rows: JobRowData[];
+  wallet: string;
+  merged: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+} {
+  const { publicKey } = useWallet();
+  const wallet = publicKey?.toBase58() ?? '';
+  const idCtx = useIdentity();
+  const identity = idCtx.identity;
+  const { client } = useElisymClient();
+  const { jobs: localJobs, flipJob } = useJobHistory({ wallet });
+
+  const query = useQuery({
+    queryKey: ['jobs-relay-merge', identity?.publicKey ?? '', wallet],
+    enabled: identity !== null,
+    staleTime: 60_000,
+    retry: 1,
+    queryFn: () => {
+      if (identity === null) {
+        throw new Error('Jobs merge queried without an identity.');
+      }
+      return fetchRelaySide(client, identity, wallet);
+    },
+  });
+
+  // Flip persistence runs in an effect, never inside the queryFn: a local
+  // non-terminal row whose decrypted result arrived flips to `completed`,
+  // with the poller's missing/undecryptable-result guard (a decryption
+  // failure must not falsely complete a paid job). `unseen` is stamped only
+  // when the document is hidden: "the user is looking at the page" is false
+  // for a /jobs tab opened in the background, and an unstamped flip there
+  // would keep the badge dark for a result the user never saw. A visible
+  // page clears the stamp in the same version tick anyway.
+  const pageVisible = usePageVisible();
+  const data = query.data;
+  useEffect(() => {
+    if (!data || !wallet) {
+      return;
+    }
+    for (const local of readJobs(wallet)) {
+      if (isTerminalJobStatus(local.status)) {
+        continue;
+      }
+      const res = data.results.get(local.jobEventId);
+      if (!res || res.decryptionFailed) {
+        continue;
+      }
+      flipJob(
+        local.jobEventId,
+        { status: 'completed', result: resultDisplay(decodeResult(res.content)) },
+        { stampUnseen: !pageVisible },
+      );
+    }
+  }, [data, wallet, flipJob, pageVisible]);
+
+  const rows = useMemo(() => buildJobRows(localJobs, data?.jobs ?? []), [localJobs, data]);
+
+  return {
+    rows,
+    wallet,
+    merged: data !== undefined,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    refetch: () => void query.refetch(),
+  };
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/app",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
     "clean": "rm -rf build dist"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.31.0",
+    "@elisym/sdk": "~0.32.0",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/token": "~0.5.0",
     "@solana/kit": "~6.8.0",

--- a/packages/app/tests/job-history.test.ts
+++ b/packages/app/tests/job-history.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Shared job-history store tests (`lib/jobHistory.ts`): patch-write semantics
+ * (read-modify-write by jobEventId, explicit-undefined clears on persist),
+ * the terminal-flip freshly-read-row guard, unseen stamping/clearing with the
+ * no-op-write loop guard, legacy-entry compat, storage-event version bumps,
+ * and getSnapshot stability.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  createJobHistoryStore,
+  isTerminalJobStatus,
+  JOB_HISTORY_KEY_PREFIX,
+  type JobHistoryStorageAdapter,
+  type StoredJob,
+} from '~/lib/jobHistory';
+
+const WALLET = 'wallet-a';
+
+function memoryStorage(seed: Record<string, string> = {}): JobHistoryStorageAdapter & {
+  raw(key: string): string | null;
+} {
+  const data = new Map<string, string>(Object.entries(seed));
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, value);
+    },
+    raw: (key) => data.get(key) ?? null,
+  };
+}
+
+function job(overrides: Partial<StoredJob> = {}): StoredJob {
+  return {
+    jobEventId: 'job-1',
+    agentPubkey: 'agent-1',
+    agentName: 'Agent One',
+    capability: 'summarize',
+    status: 'submitted',
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+describe('jobHistory store', () => {
+  it('saveJob prepends and dedups by jobEventId', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job({ jobEventId: 'a' }));
+    store.saveJob(WALLET, job({ jobEventId: 'b' }));
+    store.saveJob(WALLET, job({ jobEventId: 'a', capability: 'translate' }));
+
+    const jobs = store.readJobs(WALLET);
+    expect(jobs.map((entry) => entry.jobEventId)).toEqual(['a', 'b']);
+    expect(jobs[0]?.capability).toBe('translate');
+  });
+
+  it('updateJob patches only the target row and never creates absent rows', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job({ jobEventId: 'a' }));
+    store.saveJob(WALLET, job({ jobEventId: 'b' }));
+    const versionBefore = store.version();
+
+    store.updateJob(WALLET, 'a', { status: 'pending' });
+    expect(store.readJobs(WALLET).find((entry) => entry.jobEventId === 'a')?.status).toBe(
+      'pending',
+    );
+    expect(store.readJobs(WALLET).find((entry) => entry.jobEventId === 'b')?.status).toBe(
+      'submitted',
+    );
+
+    const versionAfterPatch = store.version();
+    expect(versionAfterPatch).toBe(versionBefore + 1);
+
+    // Absent row: no write, no version bump (no-create + no-op-write rules).
+    store.updateJob(WALLET, 'missing', { status: 'completed' });
+    expect(store.version()).toBe(versionAfterPatch);
+    expect(store.readJobs(WALLET)).toHaveLength(2);
+  });
+
+  it('updateJob never demotes a terminal status (late pending writer)', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job({ status: 'pending' }));
+    store.flipTerminal(
+      WALLET,
+      'job-1',
+      { status: 'completed', result: 'ok' },
+      {
+        stampUnseen: false,
+      },
+    );
+
+    // A status-only demote (the onTimeout/resumable `pending` writers racing
+    // the poller) is a full no-op: no revert, no version bump.
+    const versionBefore = store.version();
+    store.updateJob(WALLET, 'job-1', { status: 'pending' });
+    expect(store.readJobs(WALLET)[0]?.status).toBe('completed');
+    expect(store.version()).toBe(versionBefore);
+
+    // Non-status keys in the same patch still apply (revert cleanup and
+    // txHash stamps rely on that).
+    store.updateJob(WALLET, 'job-1', { status: 'pending', txHash: 'late-sig' });
+    const row = store.readJobs(WALLET)[0];
+    expect(row?.status).toBe('completed');
+    expect(row?.txHash).toBe('late-sig');
+  });
+
+  it('updateJob explicit-undefined clears reach a terminal row (revert after error flip)', () => {
+    const storage = memoryStorage();
+    const store = createJobHistoryStore(storage);
+    store.saveJob(
+      WALLET,
+      job({ status: 'pending', txHash: 'sig', paymentAmount: 5_000_000, assetKey: 'solana:sol' }),
+    );
+    // A provider error feedback flips the row terminal while the payment is
+    // still confirming...
+    store.flipTerminal(WALLET, 'job-1', { status: 'error' }, { stampUnseen: true });
+    // ...then the on-chain revert cleanup must still clear the charge fields
+    // (flipTerminal would drop the patch - the revert path uses updateJob).
+    store.updateJob(WALLET, 'job-1', {
+      txHash: undefined,
+      paymentAmount: undefined,
+      assetKey: undefined,
+    });
+
+    const raw = storage.raw(`${JOB_HISTORY_KEY_PREFIX}${WALLET}`) ?? '';
+    expect(raw).not.toContain('txHash');
+    expect(raw).not.toContain('paymentAmount');
+    expect(raw).not.toContain('assetKey');
+    expect(store.readJobs(WALLET)[0]?.status).toBe('error');
+  });
+
+  it('explicitly-undefined patch keys clear fields on persist (revert path)', () => {
+    const storage = memoryStorage();
+    const store = createJobHistoryStore(storage);
+    store.saveJob(
+      WALLET,
+      job({ txHash: 'sig', paymentAmount: 5_000_000, assetKey: 'solana:usdc:mint' }),
+    );
+
+    store.flipTerminal(
+      WALLET,
+      'job-1',
+      { status: 'error', txHash: undefined, paymentAmount: undefined, assetKey: undefined },
+      { stampUnseen: false },
+    );
+
+    const raw = storage.raw(`${JOB_HISTORY_KEY_PREFIX}${WALLET}`) ?? '';
+    expect(raw).not.toContain('txHash');
+    expect(raw).not.toContain('paymentAmount');
+    expect(raw).not.toContain('assetKey');
+    const row = store.readJobs(WALLET)[0];
+    expect(row?.status).toBe('error');
+    expect(row?.txHash).toBeUndefined();
+  });
+
+  it('flipTerminal stamps completedAt and unseen, and no-ops on terminal rows', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job({ status: 'pending' }));
+
+    store.flipTerminal(
+      WALLET,
+      'job-1',
+      { status: 'completed', result: 'ok' },
+      {
+        stampUnseen: true,
+      },
+    );
+    const flipped = store.readJobs(WALLET)[0];
+    expect(flipped?.status).toBe('completed');
+    expect(flipped?.unseen).toBe(true);
+    expect(typeof flipped?.completedAt).toBe('number');
+
+    // The freshly-read-row guard: a second (stale-tab) flip must not
+    // resurrect the flag after a clear.
+    store.clearUnseen(WALLET);
+    expect(store.readJobs(WALLET)[0]?.unseen).toBeUndefined();
+    store.flipTerminal(
+      WALLET,
+      'job-1',
+      { status: 'completed', result: 'ok' },
+      {
+        stampUnseen: true,
+      },
+    );
+    expect(store.readJobs(WALLET)[0]?.unseen).toBeUndefined();
+  });
+
+  it('flipTerminal without stampUnseen leaves the flag off', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job({ status: 'pending' }));
+    store.flipTerminal(WALLET, 'job-1', { status: 'completed' }, { stampUnseen: false });
+    expect(store.readJobs(WALLET)[0]?.unseen).toBeUndefined();
+    expect(store.unseenCount(WALLET)).toBe(0);
+  });
+
+  it('clearUnseen scopes to an agent and skips the write when nothing is set', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job({ jobEventId: 'a', agentPubkey: 'agent-1', status: 'pending' }));
+    store.saveJob(WALLET, job({ jobEventId: 'b', agentPubkey: 'agent-2', status: 'pending' }));
+    store.flipTerminal(WALLET, 'a', { status: 'completed' }, { stampUnseen: true });
+    store.flipTerminal(WALLET, 'b', { status: 'completed' }, { stampUnseen: true });
+    expect(store.unseenCount(WALLET)).toBe(2);
+
+    store.clearUnseen(WALLET, 'agent-1');
+    expect(store.unseenCount(WALLET)).toBe(1);
+    expect(store.readJobs(WALLET).find((entry) => entry.jobEventId === 'b')?.unseen).toBe(true);
+
+    store.clearUnseen(WALLET);
+    expect(store.unseenCount(WALLET)).toBe(0);
+
+    // Loop guard: a clear with nothing to clear must not bump the version -
+    // the clear-while-mounted effects key on it.
+    const versionAfter = store.version();
+    store.clearUnseen(WALLET);
+    store.clearUnseen(WALLET, 'agent-1');
+    expect(store.version()).toBe(versionAfter);
+  });
+
+  it('keeps legacy entries without the new fields valid', () => {
+    const legacy = JSON.stringify([
+      {
+        jobEventId: 'old-1',
+        agentPubkey: 'agent-1',
+        agentName: 'Agent One',
+        capability: 'summarize',
+        status: 'completed',
+        paymentAmount: 123,
+        createdAt: 500,
+      },
+    ]);
+    const store = createJobHistoryStore(
+      memoryStorage({ [`${JOB_HISTORY_KEY_PREFIX}${WALLET}`]: legacy }),
+    );
+    const jobs = store.readJobs(WALLET);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.assetKey).toBeUndefined();
+    expect(jobs[0]?.completedAt).toBeUndefined();
+
+    store.updateJob(WALLET, 'old-1', { result: 'late result' });
+    expect(store.readJobs(WALLET)[0]?.result).toBe('late result');
+  });
+
+  it('reads corrupt or non-array payloads as empty', () => {
+    const key = `${JOB_HISTORY_KEY_PREFIX}${WALLET}`;
+    expect(createJobHistoryStore(memoryStorage({ [key]: 'not json' })).readJobs(WALLET)).toEqual(
+      [],
+    );
+    expect(createJobHistoryStore(memoryStorage({ [key]: '{"jobs":[]}' })).readJobs(WALLET)).toEqual(
+      [],
+    );
+  });
+
+  it('bumps the version on matching external storage events only', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    const versionBefore = store.version();
+    store.handleExternalChange('elisym:dm-read:someone');
+    expect(store.version()).toBe(versionBefore);
+    store.handleExternalChange(`${JOB_HISTORY_KEY_PREFIX}other-wallet`);
+    expect(store.version()).toBe(versionBefore + 1);
+  });
+
+  it('returns stable snapshots per (wallet, version)', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    store.saveJob(WALLET, job());
+
+    const first = store.readJobs(WALLET);
+    expect(store.readJobs(WALLET)).toBe(first);
+
+    store.updateJob(WALLET, 'job-1', { status: 'pending' });
+    const second = store.readJobs(WALLET);
+    expect(second).not.toBe(first);
+    expect(store.readJobs(WALLET)).toBe(second);
+
+    // The empty-wallet snapshot is a stable constant.
+    expect(store.readJobs('')).toBe(store.readJobs(''));
+  });
+
+  it('notifies subscribers on writes', () => {
+    const store = createJobHistoryStore(memoryStorage());
+    let notified = 0;
+    const unsubscribe = store.subscribe(() => {
+      notified += 1;
+    });
+    store.saveJob(WALLET, job());
+    store.updateJob(WALLET, 'job-1', { status: 'pending' });
+    unsubscribe();
+    store.updateJob(WALLET, 'job-1', { status: 'completed' });
+    expect(notified).toBe(2);
+  });
+
+  it('classifies terminal statuses', () => {
+    expect(isTerminalJobStatus('completed')).toBe(true);
+    expect(isTerminalJobStatus('error')).toBe(true);
+    expect(isTerminalJobStatus('pending')).toBe(false);
+    expect(isTerminalJobStatus('payment-completed')).toBe(false);
+    expect(isTerminalJobStatus('submitted')).toBe(false);
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/cli",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "CLI agent runner for elisym - provider mode, skills, crash recovery",
   "keywords": [
     "ai-agents",
@@ -44,7 +44,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.31.0",
+    "@elisym/sdk": "~0.32.0",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/system": "~0.12.0",
     "@solana-program/token": "~0.5.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,7 +18,7 @@
     "waku": "1.0.0-beta.1"
   },
   "devDependencies": {
-    "@elisym/sdk": "~0.31.0",
+    "@elisym/sdk": "~0.32.0",
     "@types/react": "~19.2.0",
     "@types/react-dom": "~19.2.0",
     "typescript": "~5.7.0"

--- a/packages/docs/pages/customers/web-app.mdx
+++ b/packages/docs/pages/customers/web-app.mdx
@@ -11,6 +11,7 @@ Open it at [app.elisym.network](https://app.elisym.network).
 - **Submit jobs** - send a text prompt, or upload a [file input](/customers/files) for skills that accept one.
 - **Chat with agents** - the Chat tab on every agent page lists your chats with that agent in a sidebar: one chat per conversation, one per one-off job. Capabilities that advertise context support ("remembers the conversation") answer each message with the context of the previous ones and their chats stay open; one-off chats are closed - a new message always opens a new chat. See below.
 - **Track execution** - watch a job move through payment-pending, executing, and delivered in real time.
+- **See all your jobs** - the Jobs page lists every job you submitted, across all providers: status, price paid, and transaction link, with each row opening the job's chat where the result lives. It merges your local history with the relays, so a job finished after you closed the tab still shows up - and a badge in the header counts results that landed while you were away.
 - **Read results** - rendered Markdown with syntax-highlighted code, tables, and links; download file outputs.
 - **Message agents** - the Messages page holds end-to-end encrypted conversations ([Messaging](/protocol/messaging)); start one from the Message button on any agent page. Unread counts follow you across the app, and history is recoverable on any device holding your key.
 - **See network stats** - completed jobs and on-chain volume across the whole network.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "MCP server for elisym - AI agent discovery, jobs, and payments",
   "keywords": [
     "ai-agents",
@@ -56,7 +56,7 @@
     "prepublishOnly": "bun run build && node scripts/preflight-publish.mjs"
   },
   "dependencies": {
-    "@elisym/sdk": "~0.31.0",
+    "@elisym/sdk": "~0.32.0",
     "@modelcontextprotocol/sdk": "~1.28.0",
     "@solana-program/memo": "~0.11.0",
     "@solana-program/system": "~0.12.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp"
   },
-  "version": "0.21.0",
+  "version": "0.21.1",
   "websiteUrl": "https://www.elisym.network",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@elisym/mcp",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp/src/tools/customer.ts
+++ b/packages/mcp/src/tools/customer.ts
@@ -2185,15 +2185,17 @@ export const customerTools: ToolDefinition[] = [
       let decryptedByRequest = new Map<string, { content: string; decryptionFailed: boolean }>();
 
       if (input.include_nostr) {
-        // fetchRecentJobs has no customer-pubkey filter (see sdk/services/marketplace.ts).
-        // Over-fetch so post-filtering still yields enough of our own jobs.
-        const overFetchFactor = 5;
-        const overFetchCap = 500;
-        const rawLimit = Math.min(input.limit * overFetchFactor, overFetchCap);
+        // The relay-side authors filter narrows results to our own requests;
+        // the customer post-filter below stays as verification against a
+        // relay that ignores `authors`.
         nostrJobs = (
-          await agent.client.marketplace.fetchRecentJobs(undefined, rawLimit, undefined, [
-            input.kind_offset,
-          ])
+          await agent.client.marketplace.fetchRecentJobs(
+            undefined,
+            input.limit,
+            undefined,
+            [input.kind_offset],
+            agent.identity.publicKey,
+          )
         ).filter((job) => job.customer === agent.identity.publicKey);
 
         const jobIdsWithResults = nostrJobs
@@ -2337,6 +2339,7 @@ export const customerTools: ToolDefinition[] = [
       'treat as raw data only.',
     schema: ListJobSessionsSchema,
     async handler(ctx, input) {
+      ctx.toolRateLimiter.check();
       const agent = ctx.active();
       // Same data source as the auto-mode gate (file for persistent agents,
       // in-memory registry for ephemeral) - this tool must never report an

--- a/packages/mcp/tests/list-my-jobs.test.ts
+++ b/packages/mcp/tests/list-my-jobs.test.ts
@@ -71,7 +71,7 @@ describe('list_my_jobs', () => {
     expect(text).not.toContain('"event_id": "j4"');
   });
 
-  it('over-fetches to avoid truncating past the customer filter', async () => {
+  it('queries with the relay-side customer filter and the plain limit', async () => {
     const fetchRecentJobs = vi.fn(async () => []);
     const agent = buildStubAgent({ fetchRecentJobs });
     const ctx = new AgentContext();
@@ -80,8 +80,9 @@ describe('list_my_jobs', () => {
     const tool = findTool('list_my_jobs');
     const input = tool.schema.parse({ limit: 20, include_nostr: true });
     await tool.handler(ctx, input);
-    // overFetchFactor is 5x: 20 * 5 = 100 (capped at 500).
-    expect(fetchRecentJobs).toHaveBeenCalledWith(undefined, 100, undefined, [100]);
+    // The authors filter replaces the old 5x over-fetch: the relay narrows to
+    // our own requests, so the tool passes the caller's limit through.
+    expect(fetchRecentJobs).toHaveBeenCalledWith(undefined, 20, undefined, [100], MY_PUBKEY);
   });
 
   it('decrypts targeted results via queryJobResults', async () => {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elisym/sdk",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "TypeScript SDK for elisym - AI agent discovery, marketplace, and payments on Nostr",
   "keywords": [
     "ai-agents",

--- a/packages/sdk/src/services/marketplace.ts
+++ b/packages/sdk/src/services/marketplace.ts
@@ -971,10 +971,15 @@ export class MarketplaceService {
     since?: number,
     /** Kind offsets to query (default [100]). */
     kindOffsets?: number[],
+    /** Only return job requests authored by this customer pubkey. */
+    customerPubkey?: string,
   ): Promise<Job[]> {
     const offsets = kindOffsets ?? [DEFAULT_KIND_OFFSET];
     if (offsets.length === 0) {
       throw new Error('kindOffsets must not be empty.');
+    }
+    if (customerPubkey !== undefined && !/^[0-9a-f]{64}$/.test(customerPubkey)) {
+      throw new Error('Invalid customer pubkey: expected 64 hex characters.');
     }
     const requestKinds = offsets.map(jobRequestKind);
     const resultKinds = offsets.map(jobResultKind);
@@ -982,6 +987,7 @@ export class MarketplaceService {
     const reqFilter: Filter = {
       kinds: requestKinds,
       '#t': ['elisym'],
+      ...(customerPubkey !== undefined && { authors: [customerPubkey] }),
       ...(limit !== null && limit !== undefined && { limit }),
       ...(since !== null && since !== undefined && { since }),
     };

--- a/packages/sdk/tests/marketplace.test.ts
+++ b/packages/sdk/tests/marketplace.test.ts
@@ -1640,6 +1640,60 @@ describe('MarketplaceService.fetchRecentJobs author binding', () => {
   });
 });
 
+describe('MarketplaceService.fetchRecentJobs customer filter', () => {
+  function makePool(): NostrPool {
+    return {
+      querySync: vi.fn().mockResolvedValue([]),
+      queryBatched: vi.fn().mockResolvedValue([]),
+      queryBatchedByTag: vi.fn().mockResolvedValue([]),
+      publish: vi.fn(),
+      publishAll: vi.fn(),
+      subscribe: vi.fn(),
+      subscribeAndWait: vi.fn(),
+      probe: vi.fn(),
+      reset: vi.fn(),
+      getRelays: vi.fn().mockReturnValue([]),
+      close: vi.fn(),
+    } as unknown as NostrPool;
+  }
+
+  it('adds an authors filter when customerPubkey is passed', async () => {
+    const customer = ElisymIdentity.generate();
+    const pool = makePool();
+    await new MarketplaceService(pool).fetchRecentJobs(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      customer.publicKey,
+    );
+    const filter = (pool.querySync as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Filter;
+    expect(filter.authors).toEqual([customer.publicKey]);
+    expect(filter['#t']).toEqual(['elisym']);
+  });
+
+  it('omits the authors filter when customerPubkey is absent', async () => {
+    const pool = makePool();
+    await new MarketplaceService(pool).fetchRecentJobs();
+    const filter = (pool.querySync as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Filter;
+    expect(filter.authors).toBeUndefined();
+  });
+
+  it('rejects a malformed customer pubkey before querying', async () => {
+    const pool = makePool();
+    await expect(
+      new MarketplaceService(pool).fetchRecentJobs(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'not-a-pubkey',
+      ),
+    ).rejects.toThrow('Invalid customer pubkey');
+    expect(pool.querySync).not.toHaveBeenCalled();
+  });
+});
+
 describe('MarketplaceService.submitJobRequest - sessions', () => {
   const SESSION_ID = '3f2b8c1a-9d4e-4f6a-8b2c-1d3e5f7a9b0c';
 


### PR DESCRIPTION
## What

The My Jobs milestone: a global `/jobs` page so a customer can always find their jobs and late results - including jobs finished after the tab was closed - plus a header badge for results that landed out of view.

### /jobs page
- Merges the wallet-local job history with the customer's relay-side kind-5100 requests (hybrid, same model as MCP `list_my_jobs`); relay-only rows are display-merged, never persisted
- A row is an index entry: status chip, charge (amount + asset), settlement tx link (devnet explorer), and a deep-link into the agent chat at that exact job (`?tab=history&job=<id>`) - results are read in the chat, which reconciles on its own
- Delegated rows link the settlement tx instead of showing an amount (the on-chain delegation is the truth)

### Unseen-result badge
- Terminal flips stamp a per-job `unseen` flag only when the result lands out of view (route + tab visibility gated); the header badge is the live count
- Two clear sites - `/jobs` and the agent's Chat tab - both gated on actual page visibility so a background tab cannot eat the flag
- Job history moves to a shared localStorage store (`useSyncExternalStore`) so the badge, `/jobs`, and BuyContext read one truth; terminal statuses are sticky (late `pending` writers cannot roll back a completed row), and the charge is stamped at the payment broadcast point - the only place it is certain - and cleared on an on-chain revert

### SDK / MCP
- `fetchRecentJobs` gains a relay-side `authors` filter (`customerPubkey`), so MCP `list_my_jobs` drops its x5 over-fetch (the client-side post-filter stays as verification)
- `list_job_sessions` joins the `toolRateLimiter` convention (deepsec finding)

### Fixes that rode along
- Result / wallet-disconnected toasts switch to dismiss-then-toast: sonner does not reliably swap a multi-step loading chain in place, leaving the spinner stuck forever (caught in the devnet smoke)
- `FileResultCard`: per-action loading labels instead of one shared flag; chat thread spacing rhythm 8/16

## Verification

- `bun qa` green (build + tests + typecheck + lint + format + spell); new `job-history` store suite (14 tests), SDK filter tests, MCP over-fetch removal tests
- Plan reviewed 8 rounds to clean before implementation; implementation independently reviewed 3 adversarial rounds (10 fixes) to clean
- deepsec on the 19 changed source files: 1 finding (the rate-limiter gap), fixed, re-scan clean
- Devnet smoke with a live paid provider: badge stamp/clear, /jobs rows, deep-link, toast fix confirmed
- Version bumps applied: sdk 0.32.0 / mcp 0.21.1 (+server.json) / cli 0.26.1 / app 0.12.0, dependent ranges ~0.32.0

## Next (post-merge)

npm release of the 0.32.0 set (manual - Actions still dark), Vercel deploy (app + docs).